### PR TITLE
feat(argus,csc): add security contexts to pod

### DIFF
--- a/charts/argus/Chart.yaml
+++ b/charts/argus/Chart.yaml
@@ -6,6 +6,11 @@ maintainers:
   - email: argus@logicmonitor.com
     name: LogicMonitor
 name: argus
-version: 5.1.0-rc02
+version: 5.1.0-rc03
 home: https://logicmonitor.github.io/helm-charts-qa
-appVersion: v10.1.0-rc02
+appVersion: v10.1.0-rc03
+dependencies:
+  - name: lmutil
+    repository: https://logicmonitor.github.io/helm-charts-qa
+    # repository: file://../lmutil
+    version: 0.1.1

--- a/charts/argus/templates/_helpers.tpl
+++ b/charts/argus/templates/_helpers.tpl
@@ -1,65 +1,20 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "argus.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "argus.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "argus.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
 
 {{/*
 Common labels
 */}}
 {{- define "argus.labels" -}}
-helm.sh/chart: {{ include "argus.chart" . }}
+{{ include "lmutil.generic.labels" . }}
 app.kubernetes.io/component: discovery-agent
-app.kubernetes.io/part-of: {{ template "argus.name" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Adding app property to make it backward compatible in trasition phase.
 New datasources or existing datasources should use app.kubernetes.io/name property in its appliesto script
 */}}
 app: argus
-{{ include "argus.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+{{ include "lmutil.selectorLabels" . }}
 {{- if .Values.labels }}
 {{ toYaml .Values.labels }}
 {{- end }}
-{{- end }}
-
-{{/*
-Selector labels
-*/}}
-{{- define "argus.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "argus.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
@@ -71,39 +26,6 @@ logicmonitor.com/provider: lm-container
 {{ toYaml .Values.annotations }}
 {{- end }}
 {{- end }}
-
-{{/*
-Create the name of the service account to use
-*/}}
-{{- define "argus.serviceAccountName" -}}
-{{- if .Values.serviceAccount.create }}
-{{- default (include "argus.fullname" .) .Values.serviceAccount.name }}
-{{- else }}
-{{- default "default" .Values.serviceAccount.name }}
-{{- end }}
-{{- end }}
-
-{{/*
-Allow the release namespace to be overridden for multi-namespace deployments in combined charts
-*/}}
-{{- define "argus.namespace" -}}
-  {{- if .Values.namespaceOverride -}}
-    {{- .Values.namespaceOverride -}}
-  {{- else -}}
-    {{- .Release.Namespace -}}
-  {{- end -}}
-{{- end -}}
-
-{{/*
-Return the appropriate apiVersion for rbac.
-*/}}
-{{- define "rbac.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
-{{- print "rbac.authorization.k8s.io/v1" -}}
-{{- else -}}
-{{- print "rbac.authorization.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
 
 
 
@@ -139,7 +61,7 @@ Return the appropriate apiVersion for rbac.
 
 {{- define "collector.labels" }}
 {{ $default := dict }}
-{{ $_ := set $default "app.kubernetes.io/part-of" (include "argus.name" .)}}
+{{ $_ := set $default "app.kubernetes.io/part-of" (include "lmutil.name" .)}}
 {{- $result := (merge $default .Values.collector.labels)}}
 {{- toYaml $result | nindent 0 }}
 {{/*
@@ -148,11 +70,6 @@ New datasources or existing datasources should use app.kubernetes.io/name proper
 */}}
 app: collector
 {{- end }}
-
-{{ define "argus.imagePullSecrets" }}
-{{ $result := (concat .Values.imagePullSecrets .Values.global.imagePullSecrets | uniq)}}
-{{ toYaml $result | nindent 0 }}
-{{ end }}
 
 
 {{- define "argus-image" -}}
@@ -186,23 +103,25 @@ app: collector
 "{{ $repo }}/{{ .Values.collector.image.name }}"
 {{- end -}}
 
-{{- define "psp" }}
-{{ toYaml .Values.podSecurityContext | nindent 0 }}
+
+{{/*
+Collector Pod security context
+*/}}
+{{- define "collector-psp" }}
+{{ toYaml .Values.collector.podSecurityContext | nindent 0 }}
 {{- end }}
 
-{{- define "csp" }}
-{{- $addCaps := .Values.securityContext.capabilities.add }}
-{{- if and (contains "-gke" .Capabilities.KubeVersion.Version) (not (has "NET_RAW" $addCaps)) }}
+{{- define "collector-csp" }}
+{{- $addCaps := .Values.collector.securityContext.capabilities.add }}
+{{- if and (eq (include "lmutil.get-platform" .) "gke") (not (has "NET_RAW" $addCaps)) }}
 {{- $addCaps = append $addCaps "NET_RAW" }}
 {{- end }}
-
-{{- with .Values.securityContext }}
+{{- with .Values.collector.securityContext }}
 {{- if not (hasKey . "capabilities") }}
 {{ toYaml . | nindent 0 }}
 {{- end }}
 {{- end }}
-
 capabilities:
-  drop: {{ toYaml .Values.securityContext.capabilities.drop | nindent 4 }}
+  drop: {{ toYaml .Values.collector.securityContext.capabilities.drop | nindent 4 }}
   add: {{ toYaml $addCaps | nindent 4 }}
 {{- end }}

--- a/charts/argus/templates/_helpers.tpl
+++ b/charts/argus/templates/_helpers.tpl
@@ -185,3 +185,24 @@ app: collector
 {{- end -}}
 "{{ $repo }}/{{ .Values.collector.image.name }}"
 {{- end -}}
+
+{{- define "psp" }}
+{{ toYaml .Values.podSecurityContext | nindent 0 }}
+{{- end }}
+
+{{- define "csp" }}
+{{- $addCaps := .Values.securityContext.capabilities.add }}
+{{- if and (contains "-gke" .Capabilities.KubeVersion.Version) (not (has "NET_RAW" $addCaps)) }}
+{{- $addCaps = append $addCaps "NET_RAW" }}
+{{- end }}
+
+{{- with .Values.securityContext }}
+{{- if not (hasKey . "capabilities") }}
+{{ toYaml . | nindent 0 }}
+{{- end }}
+{{- end }}
+
+capabilities:
+  drop: {{ toYaml .Values.securityContext.capabilities.drop | nindent 4 }}
+  add: {{ toYaml $addCaps | nindent 4 }}
+{{- end }}

--- a/charts/argus/templates/collector-conf.yaml
+++ b/charts/argus/templates/collector-conf.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "argus.fullname" . }}-collector
-  namespace: {{ template "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}-collector
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "argus.labels" . | nindent 4 }}
   annotations:

--- a/charts/argus/templates/collectorset.yaml
+++ b/charts/argus/templates/collectorset.yaml
@@ -1,8 +1,8 @@
 apiVersion: logicmonitor.com/v1beta1
 kind: CollectorSet
 metadata:
-  name: {{ include "argus.fullname" . }}
-  namespace: {{ template "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "argus.labels" . | nindent 4 }}
   annotations:
@@ -35,13 +35,13 @@ spec:
   proxy:
     url: {{ .Values.collector.proxy.url }}
   {{- if .Values.collector.proxy.user }}
-  secretName: {{ include "argus.fullname" . }}-collector
+  secretName: {{ include "lmutil.fullname" . }}-collector
   {{- end }}
   {{- else if .Values.global.proxy.url }}
   proxy:
     url: {{ .Values.global.proxy.url }}
   {{- if .Values.global.proxy.user }}
-  secretName: {{ include "argus.fullname" . }}-collector
+  secretName: {{ include "lmutil.fullname" . }}-collector
   {{- end }}
   {{- end }}
   labels:
@@ -60,4 +60,6 @@ spec:
     {{ toYaml .Values.collector.statefulsetSpec | nindent 4 }}
   {{- end }}
   probe: {{ toYaml .Values.collector.probe | nindent 4 }}
-  collectorConfigMapName: {{ include "argus.fullname" . }}-collector
+  collectorConfigMapName: {{ include "lmutil.fullname" . }}-collector
+  securityContext: {{ include "collector-csp" . | nindent 4 }}
+  podSecurityContext: {{ include "collector-psp" . | nindent 4 }}

--- a/charts/argus/templates/configmap.yaml
+++ b/charts/argus/templates/configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "argus.fullname" . }}
-  namespace: {{ template "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     logicmonitor.com/version: v3
     {{- include "argus.labels" . | nindent 4 }}
@@ -13,13 +13,6 @@ metadata:
     strategy.spinnaker.io/versioned: "false"
     {{- include "argus.annotations" . | nindent 4 }}
 data:
-  debug-info: |
-    capabilities:
-      {{- toYaml .Capabilities | nindent 6 }}
-    release:
-      {{- toYaml .Release | nindent 6 }}
-    values:
-      {{- toYaml .Values | nindent 6 }}
   config.yaml: |
     {{- include "argus-config" . | fromYaml | toYaml | nindent 4 }}
   filters-config.yaml: |

--- a/charts/argus/templates/deployment.yaml
+++ b/charts/argus/templates/deployment.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "argus.fullname" . }}
-  namespace: {{ include "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ include "lmutil.release.namespace" . }}
   labels:
     {{ include "argus.labels" . | nindent 4 }}
   annotations:
@@ -13,7 +13,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{ include "argus.selectorLabels" . | nindent 6 }}
+      {{ include "lmutil.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
@@ -21,8 +21,8 @@ spec:
       annotations:
         {{ include "argus.annotations" . | nindent 8 }}
     spec:
-      securityContext: {{ include "psp" . | nindent 8 }}
-      serviceAccountName: {{ include "argus.serviceAccountName" . }}
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
+      serviceAccountName: {{ include "lmutil.serviceAccountName" . }}
     {{ if .Values.affinity }}
       affinity:
 {{ toYaml .Values.affinity | nindent 8 }}
@@ -40,7 +40,7 @@ spec:
     {{ end }}
       containers:
         - name: argus
-          securityContext: {{ include "csp" . | nindent 12 }}
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "argus-image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default (.Values.global.image.pullPolicy | default "Always") }}
           {{ with .Values.resources }}
@@ -79,40 +79,40 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: APP_KUBERNETES_IO_NAME
-              value: {{ include "argus.name" . }}
+              value: {{ template "lmutil.name" . }}
             - name: APP_KUBERNETES_IO_INSTANCE
               value: {{ .Release.Name }}
             - name: ACCESS_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "argus.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: accessID
             - name: ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "argus.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: accessKey
             - name: ACCOUNT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "argus.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: account
             - name: ETCD_DISCOVERY_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "argus.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: etcdDiscoveryToken
         {{- if .Values.proxy.user }}
             - name: PROXY_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "argus.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: proxyUser
         {{- end }}
         {{- if .Values.proxy.pass }}
             - name: PROXY_PASS
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "argus.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: proxyPass
         {{- end }}

--- a/charts/argus/templates/deployment.yaml
+++ b/charts/argus/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
       annotations:
         {{ include "argus.annotations" . | nindent 8 }}
     spec:
+      securityContext: {{ include "psp" . | nindent 8 }}
       serviceAccountName: {{ include "argus.serviceAccountName" . }}
     {{ if .Values.affinity }}
       affinity:
@@ -39,6 +40,7 @@ spec:
     {{ end }}
       containers:
         - name: argus
+          securityContext: {{ include "csp" . | nindent 12 }}
           image: {{ include "argus-image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default (.Values.global.image.pullPolicy | default "Always") }}
           {{ with .Values.resources }}

--- a/charts/argus/templates/rbac.yaml
+++ b/charts/argus/templates/rbac.yaml
@@ -1,10 +1,10 @@
 {{- if .Values.rbac.create -}}
 ---
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "lmutil.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
-  name: {{ include "argus.fullname" . }}
-  namespace: {{ template "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "argus.labels" . | nindent 4 }}
   annotations:
@@ -16,10 +16,10 @@ aggregationRule:
 rules: [ ] # The control plane automatically fills in the rules
 ---
 kind: ClusterRole
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "lmutil.rbac.apiVersion" . }}
 metadata:
-  name: {{ include "argus.fullname" . }}-child
-  namespace: {{ template "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}-child
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     logicmonitor.com/aggregate-to-argus: "true"
     {{- include "argus.labels" . | nindent 4 }}
@@ -154,11 +154,11 @@ rules:
     verbs:
       - get
 ---
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "lmutil.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "argus.fullname" . }}
-  namespace: {{ template "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
 {{- if .Values.labels}}
   labels:
 {{ toYaml .Values.labels| indent 4 }}
@@ -170,9 +170,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "argus.fullname" . }}
+  name: {{ include "lmutil.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "argus.serviceAccountName" . }}
-    namespace: {{ template "argus.namespace" . }}
+    name: {{ include "lmutil.serviceAccountName" . }}
+    namespace: {{ template "lmutil.release.namespace" . }}
 {{- end -}}

--- a/charts/argus/templates/secret.yaml
+++ b/charts/argus/templates/secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "argus.fullname" . }}
-  namespace: {{ include "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ include "lmutil.release.namespace" . }}
   labels:
     {{- include "argus.labels" . | nindent 4 }}
   annotations:
@@ -31,8 +31,8 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "argus.fullname" . }}-collector
-  namespace: {{ template "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}-collector
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "argus.labels" . | nindent 4 }}
   annotations:

--- a/charts/argus/templates/service.yaml
+++ b/charts/argus/templates/service.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "argus.fullname" . }}
-  namespace: {{ template "argus.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "argus.labels" . | nindent 4 }}
   annotations:
@@ -24,4 +24,4 @@ spec:
       name: profiling
   {{- end }}
   selector:
-    {{- include "argus.selectorLabels" . | nindent 4 }}
+    {{- include "lmutil.selectorLabels" . | nindent 4 }}

--- a/charts/argus/templates/serviceaccount.yaml
+++ b/charts/argus/templates/serviceaccount.yaml
@@ -2,12 +2,12 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "argus.serviceAccountName" . }}
-  namespace: {{ template "argus.namespace" . }}
+  name: {{ include "lmutil.serviceAccountName" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "argus.labels" . | nindent 4 }}
   annotations:
     {{- include "argus.annotations" . | nindent 4 }}
 imagePullSecrets:
-  {{- include "argus.imagePullSecrets" . | nindent 2 }}
+  {{- include "lmutil.imagePullSecrets" . | nindent 2 }}
 {{ end }}

--- a/charts/argus/values.schema.json
+++ b/charts/argus/values.schema.json
@@ -2053,6 +2053,14 @@
             }
           },
           "additionalProperties": false
+        },
+        "securityContext": {
+          "$id": "#/properties/collector/properties/securityContext",
+          "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext"
+        },
+        "podSecurityContext": {
+          "$id": "#/properties/collector/properties/podSecurityContext",
+          "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext"
         }
       },
       "additionalProperties": false
@@ -2409,6 +2417,10 @@
         }
       },
       "additionalProperties": false
+    },
+    "lmutil": {
+      "$id": "#/properties/lmutil",
+      "additionalProperties": true
     }
   },
   "additionalProperties": false,

--- a/charts/argus/values.schema.json
+++ b/charts/argus/values.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema",
-  "$id": "http://example.com/example.json",
+  "$id": "https://example.com/example.json",
   "type": "object",
   "title": "Argus Helm Chart Configuration Schema",
   "description": "The Argus Helm Chart Configuration Schema",
@@ -409,7 +409,7 @@
       "type": "object",
       "$comment": "tf:optional,yamlencode",
       "title": "The Argus extra labels schema",
-      "description": "Labels to apply on all objects created by Argus. Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels",
+      "description": "Labels to apply on all objects created by Argus. Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: https://kubernetes.io/docs/user-guide/labels",
       "default": {},
       "examples": [
         {}
@@ -423,7 +423,7 @@
       "$id": "#/properties/annotations",
       "type": "object",
       "title": "The Argus extra annotations schema",
-      "description": "Annotations to apply on all objects created by Argus. Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations",
+      "description": "Annotations to apply on all objects created by Argus. Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: https://kubernetes.io/docs/user-guide/annotations",
       "default": {},
       "examples": [
         {}
@@ -2306,6 +2306,14 @@
       },
       "additionalProperties": false
     },
+    "securityContext": {
+      "$id": "#/properties/securityContext",
+      "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext"
+    },
+    "podSecurityContext": {
+      "$id": "#/properties/podSecurityContext",
+      "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext"
+    },
     "imagePullSecrets": {
       "$comment": "tf:optional,yamlencode",
       "$id": "#/properties/imagePullSecrets",
@@ -2595,6 +2603,184 @@
         "name": {
           "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodSecurityContext": {
+      "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+      "properties": {
+        "fsGroup": {
+          "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "fsGroupChangePolicy": {
+          "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified defaults to \"Always\".",
+          "type": "string"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+        },
+        "supplementalGroups": {
+          "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "sysctls": {
+          "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Sysctl"
+          },
+          "type": "array"
+        },
+        "windowsOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SELinuxOptions": {
+      "description": "SELinuxOptions are the labels to be applied to the container",
+      "properties": {
+        "level": {
+          "description": "Level is SELinux level label that applies to the container.",
+          "type": "string"
+        },
+        "role": {
+          "description": "Role is a SELinux role label that applies to the container.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is a SELinux type label that applies to the container.",
+          "type": "string"
+        },
+        "user": {
+          "description": "User is a SELinux user label that applies to the container.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Sysctl": {
+      "description": "Sysctl defines a kernel parameter to be set",
+      "properties": {
+        "name": {
+          "description": "Name of a property to set",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of a property to set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.WindowsSecurityContextOptions": {
+      "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+      "properties": {
+        "gmsaCredentialSpec": {
+          "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+          "type": "string"
+        },
+        "gmsaCredentialSpecName": {
+          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+          "type": "string"
+        },
+        "runAsUserName": {
+          "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Capabilities": {
+      "description": "Adds and removes POSIX capabilities from running containers.",
+      "properties": {
+        "add": {
+          "description": "Added capabilities",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "drop": {
+          "description": "Removed capabilities",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecurityContext": {
+      "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+          "type": "boolean"
+        },
+        "capabilities": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities",
+          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime."
+        },
+        "privileged": {
+          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+          "type": "boolean"
+        },
+        "procMount": {
+          "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+          "type": "string"
+        },
+        "readOnlyRootFilesystem": {
+          "description": "Whether this container has a read-only root filesystem. Default is false.",
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+        },
+        "windowsOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
         }
       },
       "type": "object"

--- a/charts/argus/values.yaml
+++ b/charts/argus/values.yaml
@@ -177,6 +177,11 @@ collector:
       periodSeconds: 10
 
 imagePullSecrets: []
+podSecurityContext: {}
+securityContext:
+  capabilities:
+    add: []
+    drop: []
 
 global:
   accessID: ""

--- a/charts/argus/values.yaml
+++ b/charts/argus/values.yaml
@@ -140,6 +140,11 @@ collector:
     pullPolicy: ""
   ## OPTIONAL VALUES
 
+  securityContext:
+    capabilities:
+      add: []
+      drop: []
+  podSecurityContext: {}
   disableLightweightCollector: false
   # collector application configuration such as agent.conf
   collectorConf:
@@ -177,7 +182,10 @@ collector:
       periodSeconds: 10
 
 imagePullSecrets: []
-podSecurityContext: {}
+podSecurityContext:
+  fsGroup: 65534
+  runAsGroup: 65534
+  runAsUser: 65534
 securityContext:
   capabilities:
     add: []

--- a/charts/collectorset-controller/Chart.yaml
+++ b/charts/collectorset-controller/Chart.yaml
@@ -6,6 +6,11 @@ maintainers:
   - email: argus@logicmonitor.com
     name: LogicMonitor
 name: collectorset-controller
-version: 4.1.0-rc03
+version: 4.1.0-rc04
 home: https://logicmonitor.github.io/helm-charts-qa
-appVersion: v6.1.0-rc1
+appVersion: v6.1.0-rc2
+dependencies:
+  - name: lmutil
+    repository: https://logicmonitor.github.io/helm-charts-qa
+    # repository: file://../lmutil
+    version: 0.1.1

--- a/charts/collectorset-controller/crds/collectorset.yaml
+++ b/charts/collectorset-controller/crds/collectorset.yaml
@@ -50,7 +50,7 @@ spec:
                 env:
                   additionalProperties:
                     type: string
-                  description: The Environment Variables to inject into the collector pod
+                  description: Environment variable to set in collector pod
                   type: object
                 escalationChainID:
                   description: The escalation chain Id of the collectors
@@ -567,11 +567,6 @@ spec:
           properties:
             spec:
               properties:
-                env:
-                  additionalProperties:
-                    type: string
-                  description: The Environment Variables to inject into the collector pod
-                  type: object
                 annotations:
                   additionalProperties:
                     type: string
@@ -581,6 +576,15 @@ spec:
                   description: The clustername of the collector
                   minLength: 1
                   type: string
+                collectorConfigMapName:
+                  description: ConfigMap Name of Collector Configuration
+                  type: string
+                env:
+                  additionalProperties:
+                    type: string
+                  description: The Environment Variables to inject into the collector
+                    pod
+                  type: object
                 escalationChainID:
                   description: The escalation chain Id of the collectors
                   minimum: 0
@@ -624,6 +628,124 @@ spec:
                   additionalProperties:
                     type: string
                   description: The Labels of the collector
+                  type: object
+                podSecurityContext:
+                  description: PodSecurityContext holds pod-level security attributes
+                    and common container settings. Some fields are also present in container.securityContext.  Field
+                    values of container.securityContext take precedence over field values
+                    of PodSecurityContext.
+                  properties:
+                    fsGroup:
+                      description: |-
+                        A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:
+                        
+                        1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----
+                        
+                        If unset, the Kubelet will not modify the ownership and permissions of any volume.
+                      format: int64
+                      type: integer
+                    fsGroupChangePolicy:
+                      description: 'fsGroupChangePolicy defines behavior of changing
+                      ownership and permission of the volume before being exposed
+                      inside Pod. This field will only apply to volume types which
+                      support fsGroup based ownership(and permissions). It will have
+                      no effect on ephemeral volume types such as: secret, configmaps
+                      and emptydir. Valid values are "OnRootMismatch" and "Always".
+                      If not specified defaults to "Always".'
+                      type: string
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset. May also be set in SecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence for that container.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to start
+                        the container if it does. If unset or false, no such validation
+                        will be performed. May also be set in SecurityContext.  If set
+                        in both SecurityContext and PodSecurityContext, the value specified
+                        in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in SecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence for that container.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: SELinuxOptions are the labels to be applied to the
+                        container
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    supplementalGroups:
+                      description: A list of groups applied to the first process run
+                        in each container, in addition to the container's primary GID.  If
+                        unspecified, no groups will be added to any container.
+                      items:
+                        format: int64
+                        type: integer
+                      type: array
+                    sysctls:
+                      description: Sysctls hold a list of namespaced sysctls used for
+                        the pod. Pods with unsupported sysctls (by the container runtime)
+                        might fail to launch.
+                      items:
+                        description: Sysctl defines a kernel parameter to be set
+                        properties:
+                          name:
+                            description: Name of a property to set
+                            type: string
+                          value:
+                            description: Value of a property to set
+                            type: string
+                        required:
+                          - name
+                          - value
+                        type: object
+                      type: array
+                    windowsOptions:
+                      description: WindowsSecurityContextOptions contain Windows-specific
+                        options and credentials.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named by
+                            the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
                   type: object
                 policy:
                   default:
@@ -720,6 +842,117 @@ spec:
                   default: ""
                   description: The Secret resource name of the collector
                   type: string
+                securityContext:
+                  description: SecurityContext holds security configuration that will
+                    be applied to a container. Some fields are present in both SecurityContext
+                    and PodSecurityContext.  When both are set, the values in SecurityContext
+                    take precedence.
+                  properties:
+                    allowPrivilegeEscalation:
+                      description: 'AllowPrivilegeEscalation controls whether a process
+                      can gain more privileges than its parent process. This bool
+                      directly controls if the no_new_privs flag will be set on the
+                      container process. AllowPrivilegeEscalation is true always when
+                      the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN'
+                      type: boolean
+                    capabilities:
+                      description: Adds and removes POSIX capabilities from running
+                        containers.
+                      properties:
+                        add:
+                          description: Added capabilities
+                          items:
+                            type: string
+                          type: array
+                        drop:
+                          description: Removed capabilities
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    privileged:
+                      description: Run container in privileged mode. Processes in privileged
+                        containers are essentially equivalent to root on the host. Defaults
+                        to false.
+                      type: boolean
+                    procMount:
+                      description: procMount denotes the type of proc mount to use for
+                        the containers. The default is DefaultProcMount which uses the
+                        container runtime defaults for readonly paths and masked paths.
+                        This requires the ProcMountType feature flag to be enabled.
+                      type: string
+                    readOnlyRootFilesystem:
+                      description: Whether this container has a read-only root filesystem.
+                        Default is false.
+                      type: boolean
+                    runAsGroup:
+                      description: The GID to run the entrypoint of the container process.
+                        Uses runtime default if unset. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      format: int64
+                      type: integer
+                    runAsNonRoot:
+                      description: Indicates that the container must run as a non-root
+                        user. If true, the Kubelet will validate the image at runtime
+                        to ensure that it does not run as UID 0 (root) and fail to start
+                        the container if it does. If unset or false, no such validation
+                        will be performed. May also be set in PodSecurityContext.  If
+                        set in both SecurityContext and PodSecurityContext, the value
+                        specified in SecurityContext takes precedence.
+                      type: boolean
+                    runAsUser:
+                      description: The UID to run the entrypoint of the container process.
+                        Defaults to user specified in image metadata if unspecified.
+                        May also be set in PodSecurityContext.  If set in both SecurityContext
+                        and PodSecurityContext, the value specified in SecurityContext
+                        takes precedence.
+                      format: int64
+                      type: integer
+                    seLinuxOptions:
+                      description: SELinuxOptions are the labels to be applied to the
+                        container
+                      properties:
+                        level:
+                          description: Level is SELinux level label that applies to
+                            the container.
+                          type: string
+                        role:
+                          description: Role is a SELinux role label that applies to
+                            the container.
+                          type: string
+                        type:
+                          description: Type is a SELinux type label that applies to
+                            the container.
+                          type: string
+                        user:
+                          description: User is a SELinux user label that applies to
+                            the container.
+                          type: string
+                      type: object
+                    windowsOptions:
+                      description: WindowsSecurityContextOptions contain Windows-specific
+                        options and credentials.
+                      properties:
+                        gmsaCredentialSpec:
+                          description: GMSACredentialSpec is where the GMSA admission
+                            webhook (https://github.com/kubernetes-sigs/windows-gmsa)
+                            inlines the contents of the GMSA credential spec named by
+                            the GMSACredentialSpecName field.
+                          type: string
+                        gmsaCredentialSpecName:
+                          description: GMSACredentialSpecName is the name of the GMSA
+                            credential spec to use.
+                          type: string
+                        runAsUserName:
+                          description: The UserName in Windows to run the entrypoint
+                            of the container process. Defaults to the user specified
+                            in image metadata if unspecified. May also be set in PodSecurityContext.
+                            If set in both SecurityContext and PodSecurityContext, the
+                            value specified in SecurityContext takes precedence.
+                          type: string
+                      type: object
+                  type: object
                 size:
                   default: nano
                   description: 'The collector size. Available collector sizes: nano,
@@ -1151,8 +1384,6 @@ spec:
                   invalid. For ex: 29.101 is invalid, correct input is 29101)'
                   minimum: 0
                   type: integer
-                collectorConfigMapName:
-                  type: string
               required:
                 - replicas
                 - clusterName

--- a/charts/collectorset-controller/templates/_helpers.tpl
+++ b/charts/collectorset-controller/templates/_helpers.tpl
@@ -1,66 +1,22 @@
 {{/* vim: set filetype=mustache: */}}
-{{/*
-Expand the name of the chart.
-*/}}
-{{- define "collectorset-controller.name" -}}
-{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
-{{- end }}
-
-{{/*
-Create a default fully qualified app name.
-We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
-If release name contains chart name it will be used as a full name.
-*/}}
-{{- define "collectorset-controller.fullname" -}}
-{{- if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- $name := default .Chart.Name .Values.nameOverride }}
-{{- if contains $name .Release.Name }}
-{{- .Release.Name | trunc 63 | trimSuffix "-" }}
-{{- else }}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
-{{- end }}
-{{- end }}
-{{- end }}
-
-
-{{/*
-Create chart name and version as used by the chart label.
-*/}}
-{{- define "collectorset-controller.chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
-{{- end }}
 
 {{/*
 Common labels
 */}}
 {{- define "collectorset-controller.labels" -}}
-helm.sh/chart: {{ include "collectorset-controller.chart" . }}
+{{ include "lmutil.generic.labels" . }}
 app.kubernetes.io/component: custom-resource-controller
-app.kubernetes.io/part-of: {{ template "collectorset-controller.name" . }}
-app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{/*
 Adding app property to make it backward compatible in trasition phase.
 New datasources or existing datasources should use app.kubernetes.io/name property in its appliesto script
 */}}
 app: collectorset-controller
-{{ include "collectorset-controller.selectorLabels" . }}
-{{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
-{{- end }}
+{{ include "lmutil.selectorLabels" . }}
 {{- if .Values.labels }}
 {{ toYaml .Values.labels }}
 {{- end }}
 {{- end }}
 
-{{/*
-Selector labels
-*/}}
-{{- define "collectorset-controller.selectorLabels" -}}
-app.kubernetes.io/name: {{ include "collectorset-controller.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }}
 
 {{/*
 Common Annotations
@@ -77,38 +33,15 @@ Create the name of the service account to use
 */}}
 {{- define "collectorset-controller.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create }}
-{{- default (include "collectorset-controller.fullname" .) .Values.serviceAccount.name }}
+{{- default (include "lmutil.fullname" .) .Values.serviceAccount.name }}
 {{- else }}
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
 
-{{/*
-Allow the release namespace to be overridden for multi-namespace deployments in combined charts
-*/}}
-{{- define "collectorset-controller.namespace" -}}
-  {{- if .Values.namespaceOverride -}}
-    {{- .Values.namespaceOverride -}}
-  {{- else -}}
-    {{- .Release.Namespace -}}
-  {{- end -}}
-{{- end -}}
 
-{{/*
-Return the appropriate apiVersion for rbac.
-*/}}
-{{- define "rbac.apiVersion" -}}
-{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
-{{- print "rbac.authorization.k8s.io/v1" -}}
-{{- else -}}
-{{- print "rbac.authorization.k8s.io/v1beta1" -}}
-{{- end -}}
-{{- end -}}
 
-{{ define "collectorset-controller.imagePullSecrets" }}
-{{ $result := (concat .Values.imagePullSecrets .Values.global.imagePullSecrets | uniq)}}
-{{ toYaml $result | nindent 0 }}
-{{ end }}
+
 
 
 {{- define "csc-image" -}}

--- a/charts/collectorset-controller/templates/collector-rbac.yaml
+++ b/charts/collectorset-controller/templates/collector-rbac.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.rbac.create -}}
 ---
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "lmutil.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
-  name: {{ include "collectorset-controller.fullname" . }}-collector
+  name: {{ include "lmutil.fullname" . }}-collector
   labels:
     {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:
@@ -15,9 +15,9 @@ aggregationRule:
 rules: [ ] # The control plane automatically fills in the rules
 ---
 kind: ClusterRole
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "lmutil.rbac.apiVersion" . }}
 metadata:
-  name: {{ include "collectorset-controller.fullname" . }}-collector-child
+  name: {{ include "lmutil.fullname" . }}-collector-child
   labels:
     logicmonitor.com/aggregate-to-collector: "true"
     {{- include "collectorset-controller.labels" . | nindent 4}}
@@ -131,10 +131,10 @@ rules:
     verbs:
       - get
 ---
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "lmutil.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "collectorset-controller.fullname" . }}-collector
+  name: {{ include "lmutil.fullname" . }}-collector
   labels:
       {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:
@@ -142,9 +142,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "collectorset-controller.fullname" . }}-collector
+  name: {{ include "lmutil.fullname" . }}-collector
 subjects:
   - kind: ServiceAccount
     name: {{ include "collectorset-controller.serviceAccountName" . }}-collector
-    namespace: {{ template "collectorset-controller.namespace" . }}
+    namespace: {{ template "lmutil.release.namespace" . }}
 {{- end -}}

--- a/charts/collectorset-controller/templates/configmap.yaml
+++ b/charts/collectorset-controller/templates/configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "collectorset-controller.fullname" . }}
-  namespace: {{ template "collectorset-controller.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:
@@ -12,13 +12,6 @@ metadata:
     strategy.spinnaker.io/versioned: "false"
     {{- include "collectorset-controller.annotations" . | nindent 4}}
 data:
-  debug-info: |
-    capabilities:
-      {{- toYaml .Capabilities | nindent 6 }}
-    release:
-      {{- toYaml .Release | nindent 6 }}
-    values:
-      {{- toYaml .Values | nindent 6 }}
   config.yaml: |
     log:
       {{- toYaml .Values.log | nindent 6 }}
@@ -31,4 +24,4 @@ data:
     {{- end }}
     ignoreSSL: {{ default false .Values.ignoreSSL }}
     collectorServiceAccountName: {{ include "collectorset-controller.serviceAccountName" . }}-collector
-    secretName: {{ include "collectorset-controller.fullname" . }}
+    secretName: {{ include "lmutil.fullname" . }}

--- a/charts/collectorset-controller/templates/csc-rbac.yaml
+++ b/charts/collectorset-controller/templates/csc-rbac.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.rbac.create -}}
 ---
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "lmutil.rbac.apiVersion" . }}
 kind: ClusterRole
 metadata:
-  name: {{ include "collectorset-controller.fullname" . }}
+  name: {{ include "lmutil.fullname" . }}
   labels:
     {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:
@@ -15,9 +15,9 @@ aggregationRule:
 rules: [ ] # The control plane automatically fills in the rules
 ---
 kind: ClusterRole
-apiVersion: {{ include "rbac.apiVersion" . }}
+apiVersion: {{ include "lmutil.rbac.apiVersion" . }}
 metadata:
-  name: {{ include "collectorset-controller.fullname" . }}-child
+  name: {{ include "lmutil.fullname" . }}-child
   labels:
     logicmonitor.com/aggregate-to-collectorset-controller: "true"
     {{- include "collectorset-controller.labels" . | nindent 4}}
@@ -49,10 +49,10 @@ rules:
     verbs:
       - "*"
 ---
-apiVersion: {{ template "rbac.apiVersion" . }}
+apiVersion: {{ template "lmutil.rbac.apiVersion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "collectorset-controller.fullname" . }}
+  name: {{ include "lmutil.fullname" . }}
   labels:
       {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:
@@ -60,9 +60,9 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "collectorset-controller.fullname" . }}
+  name: {{ include "lmutil.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "collectorset-controller.serviceAccountName" . }}
-    namespace: {{ template "collectorset-controller.namespace" . }}
+    namespace: {{ template "lmutil.release.namespace" . }}
 {{ end }}

--- a/charts/collectorset-controller/templates/deployment.yaml
+++ b/charts/collectorset-controller/templates/deployment.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "collectorset-controller.fullname" . }}
-  namespace: {{ template "collectorset-controller.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:
@@ -13,14 +13,15 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      {{- include "collectorset-controller.selectorLabels" . | nindent 6 }}
+      {{- include "lmutil.selectorLabels" . | nindent 6 }}
   template:
     metadata:
       labels:
         {{- include "collectorset-controller.labels" . | nindent 8 }}
       annotations:
-        {{- include "collectorset-controller.annotations" . | nindent 8}}
+        {{- include "collectorset-controller.annotations" . | nindent 8 }}
     spec:
+      securityContext: {{ toYaml .Values.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ include "collectorset-controller.serviceAccountName" . }}
     {{- with .Values.affinity }}
       affinity:
@@ -38,6 +39,7 @@ spec:
     {{- end }}
       containers:
         - name: collectorset-controller
+          securityContext: {{ toYaml .Values.securityContext | nindent 12 }}
           image: {{ include "csc-image" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default (.Values.global.image.pullPolicy | default "Always") }}
           {{ if and ( .Values.probe.enabled) ( .Values.probe.grpcContainerProbeEnabled ) ( semverCompare ">=1.24.0-0" .Capabilities.KubeVersion.Version )}}
@@ -82,35 +84,35 @@ spec:
             - name: ACCESS_ID
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "collectorset-controller.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: accessID
             - name: ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "collectorset-controller.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: accessKey
             - name: ACCOUNT
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "collectorset-controller.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: account
             - name: ETCD_DISCOVERY_TOKEN
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "collectorset-controller.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: etcdDiscoveryToken
         {{- if .Values.proxy.user }}
             - name: PROXY_USER
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "collectorset-controller.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: proxyUser
         {{- end }}
         {{- if .Values.proxy.pass }}
             - name: PROXY_PASS
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "collectorset-controller.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   key: proxyPass
         {{- end }}
           volumeMounts:
@@ -122,7 +124,7 @@ spec:
           projected:
             sources:
               - configMap:
-                  name: {{ include "collectorset-controller.fullname" . }}
+                  name: {{ include "lmutil.fullname" . }}
                   items:
                     - key: config.yaml
                       path: config.yaml

--- a/charts/collectorset-controller/templates/dummy_cs.yaml
+++ b/charts/collectorset-controller/templates/dummy_cs.yaml
@@ -3,7 +3,7 @@ apiVersion: logicmonitor.com/v1beta1
 kind: CollectorSet
 metadata:
   name: "dummy-void-cs-{{ .Release.Name }}"
-  namespace: {{ include "collectorset-controller.namespace" . }}
+  namespace: {{ include "lmutil.release.namespace" . }}
 spec:
   replicas: 0
   clusterName: "dummy-void-cs-{{ .Release.Name }}"

--- a/charts/collectorset-controller/templates/secret.yaml
+++ b/charts/collectorset-controller/templates/secret.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "collectorset-controller.fullname" . }}
-  namespace: {{ template "collectorset-controller.namespace" . }}
+  name: {{ include "lmutil.fullname" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:

--- a/charts/collectorset-controller/templates/service.yaml
+++ b/charts/collectorset-controller/templates/service.yaml
@@ -4,16 +4,16 @@ metadata:
   {{ if .Values.global.collectorsetServiceNameSuffix }}
   name: {{ (printf "%s-%s" .Release.Name .Values.global.collectorsetServiceNameSuffix) | trunc 63 | trimSuffix "-" }}
   {{ else }}
-  name: {{ include "collectorset-controller.fullname" . }}
+  name: {{ include "lmutil.fullname" . }}
   {{ end }}
-  namespace: {{ template "collectorset-controller.namespace" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:
     {{- include "collectorset-controller.annotations" . | nindent 4}}
 spec:
   selector:
-    {{- include "collectorset-controller.selectorLabels" . | nindent 4}}
+    {{- include "lmutil.selectorLabels" . | nindent 4}}
   ports:
     - protocol: TCP
       port: 50000

--- a/charts/collectorset-controller/templates/serviceaccount.yaml
+++ b/charts/collectorset-controller/templates/serviceaccount.yaml
@@ -3,23 +3,23 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "collectorset-controller.serviceAccountName" . }}
-  namespace: {{ template "collectorset-controller.namespace" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
       {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:
     {{- include "collectorset-controller.annotations" . | nindent 4}}
 imagePullSecrets:
-  {{- include "collectorset-controller.imagePullSecrets" . | nindent 2 }}
+  {{- include "lmutil.imagePullSecrets" . | nindent 2 }}
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "collectorset-controller.serviceAccountName" . }}-collector
-  namespace: {{ template "collectorset-controller.namespace" . }}
+  namespace: {{ template "lmutil.release.namespace" . }}
   labels:
     {{- include "collectorset-controller.labels" . | nindent 4}}
   annotations:
     {{- include "collectorset-controller.annotations" . | nindent 4}}
 imagePullSecrets:
-  {{- include "collectorset-controller.imagePullSecrets" . | nindent 2 }}
+  {{- include "lmutil.imagePullSecrets" . | nindent 2 }}
 {{ end }}

--- a/charts/collectorset-controller/values.schema.json
+++ b/charts/collectorset-controller/values.schema.json
@@ -678,6 +678,18 @@
         }
       },
       "additionalProperties": false
+    },
+    "securityContext": {
+      "$id": "#/properties/securityContext",
+      "$ref": "#/definitions/io.k8s.api.core.v1.SecurityContext"
+    },
+    "podSecurityContext": {
+      "$id": "#/properties/podSecurityContext",
+      "$ref": "#/definitions/io.k8s.api.core.v1.PodSecurityContext"
+    },
+    "lmutil": {
+      "$id": "#/properties/lmutil",
+      "additionalProperties": true
     }
   },
   "additionalProperties": false,
@@ -752,6 +764,184 @@
         "name": {
           "description": "Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names",
           "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.PodSecurityContext": {
+      "description": "PodSecurityContext holds pod-level security attributes and common container settings. Some fields are also present in container.securityContext.  Field values of container.securityContext take precedence over field values of PodSecurityContext.",
+      "properties": {
+        "fsGroup": {
+          "description": "A special supplemental group that applies to all containers in a pod. Some volume types allow the Kubelet to change the ownership of that volume to be owned by the pod:\n\n1. The owning GID will be the FSGroup 2. The setgid bit is set (new files created in the volume will be owned by FSGroup) 3. The permission bits are OR'd with rw-rw----\n\nIf unset, the Kubelet will not modify the ownership and permissions of any volume.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "fsGroupChangePolicy": {
+          "description": "fsGroupChangePolicy defines behavior of changing ownership and permission of the volume before being exposed inside Pod. This field will only apply to volume types which support fsGroup based ownership(and permissions). It will have no effect on ephemeral volume types such as: secret, configmaps and emptydir. Valid values are \"OnRootMismatch\" and \"Always\". If not specified defaults to \"Always\".",
+          "type": "string"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to all containers. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in SecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence for that container."
+        },
+        "supplementalGroups": {
+          "description": "A list of groups applied to the first process run in each container, in addition to the container's primary GID.  If unspecified, no groups will be added to any container.",
+          "items": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "type": "array"
+        },
+        "sysctls": {
+          "description": "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.",
+          "items": {
+            "$ref": "#/definitions/io.k8s.api.core.v1.Sysctl"
+          },
+          "type": "array"
+        },
+        "windowsOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "description": "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SELinuxOptions": {
+      "description": "SELinuxOptions are the labels to be applied to the container",
+      "properties": {
+        "level": {
+          "description": "Level is SELinux level label that applies to the container.",
+          "type": "string"
+        },
+        "role": {
+          "description": "Role is a SELinux role label that applies to the container.",
+          "type": "string"
+        },
+        "type": {
+          "description": "Type is a SELinux type label that applies to the container.",
+          "type": "string"
+        },
+        "user": {
+          "description": "User is a SELinux user label that applies to the container.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Sysctl": {
+      "description": "Sysctl defines a kernel parameter to be set",
+      "properties": {
+        "name": {
+          "description": "Name of a property to set",
+          "type": "string"
+        },
+        "value": {
+          "description": "Value of a property to set",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "value"
+      ],
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.WindowsSecurityContextOptions": {
+      "description": "WindowsSecurityContextOptions contain Windows-specific options and credentials.",
+      "properties": {
+        "gmsaCredentialSpec": {
+          "description": "GMSACredentialSpec is where the GMSA admission webhook (https://github.com/kubernetes-sigs/windows-gmsa) inlines the contents of the GMSA credential spec named by the GMSACredentialSpecName field.",
+          "type": "string"
+        },
+        "gmsaCredentialSpecName": {
+          "description": "GMSACredentialSpecName is the name of the GMSA credential spec to use.",
+          "type": "string"
+        },
+        "runAsUserName": {
+          "description": "The UserName in Windows to run the entrypoint of the container process. Defaults to the user specified in image metadata if unspecified. May also be set in PodSecurityContext. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.Capabilities": {
+      "description": "Adds and removes POSIX capabilities from running containers.",
+      "properties": {
+        "add": {
+          "description": "Added capabilities",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "drop": {
+          "description": "Removed capabilities",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "io.k8s.api.core.v1.SecurityContext": {
+      "description": "SecurityContext holds security configuration that will be applied to a container. Some fields are present in both SecurityContext and PodSecurityContext.  When both are set, the values in SecurityContext take precedence.",
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "description": "AllowPrivilegeEscalation controls whether a process can gain more privileges than its parent process. This bool directly controls if the no_new_privs flag will be set on the container process. AllowPrivilegeEscalation is true always when the container is: 1) run as Privileged 2) has CAP_SYS_ADMIN",
+          "type": "boolean"
+        },
+        "capabilities": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.Capabilities",
+          "description": "The capabilities to add/drop when running containers. Defaults to the default set of capabilities granted by the container runtime."
+        },
+        "privileged": {
+          "description": "Run container in privileged mode. Processes in privileged containers are essentially equivalent to root on the host. Defaults to false.",
+          "type": "boolean"
+        },
+        "procMount": {
+          "description": "procMount denotes the type of proc mount to use for the containers. The default is DefaultProcMount which uses the container runtime defaults for readonly paths and masked paths. This requires the ProcMountType feature flag to be enabled.",
+          "type": "string"
+        },
+        "readOnlyRootFilesystem": {
+          "description": "Whether this container has a read-only root filesystem. Default is false.",
+          "type": "boolean"
+        },
+        "runAsGroup": {
+          "description": "The GID to run the entrypoint of the container process. Uses runtime default if unset. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "runAsNonRoot": {
+          "description": "Indicates that the container must run as a non-root user. If true, the Kubelet will validate the image at runtime to ensure that it does not run as UID 0 (root) and fail to start the container if it does. If unset or false, no such validation will be performed. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "type": "boolean"
+        },
+        "runAsUser": {
+          "description": "The UID to run the entrypoint of the container process. Defaults to user specified in image metadata if unspecified. May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.",
+          "format": "int64",
+          "type": "integer"
+        },
+        "seLinuxOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.SELinuxOptions",
+          "description": "The SELinux context to be applied to the container. If unspecified, the container runtime will allocate a random SELinux context for each container.  May also be set in PodSecurityContext.  If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
+        },
+        "windowsOptions": {
+          "$ref": "#/definitions/io.k8s.api.core.v1.WindowsSecurityContextOptions",
+          "description": "The Windows specific settings applied to all containers. If unspecified, the options from the PodSecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence."
         }
       },
       "type": "object"

--- a/charts/collectorset-controller/values.yaml
+++ b/charts/collectorset-controller/values.yaml
@@ -62,6 +62,14 @@ global:
     pullPolicy: Always
   imagePullSecrets: []
 
+podSecurityContext:
+  fsGroup: 65534
+  runAsGroup: 65534
+  runAsUser: 65534
+securityContext:
+  capabilities:
+    add: []
+    drop: []
 probe:
   enabled: true
   grpcContainerProbeEnabled: true


### PR DESCRIPTION
- Add NET_RAW capability to collector pod when running on gke
- Run Collectorset controller and argus pod as non root (arbitrary user)
- Use lmutil helm chart util templates
