### PR TITLE
ci(lm-logs): add multiline_concat_key param for lm-logs

### DIFF
--- a/charts/lm-logs/Chart.yaml
+++ b/charts/lm-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for sending k8s logs to Logic Monitor
 name: lm-logs
-version: 0.5.0-rc01
+version: 0.5.1-rc01
 maintainers:
   - email: dev@logicmonitor.com
     name: LogicMonitor

--- a/charts/lm-logs/README.md
+++ b/charts/lm-logs/README.md
@@ -40,7 +40,9 @@ The following tables lists the configurable parameters of the lm-logs chart and 
 | `affinity`                  | Affinity for pod assignment		                | `{}`  (evaluated as a template)                         |
 | `env`                       | Map to add extra environment variables	        | `{}`                                                    |
 | `kubernetes.multiline_start_regexp` | Regexp to match beginning of multiline	| `/^\[(\d{4}-)?\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}.*\]/` |
-| `kubernetes.cluster_name`       | ClusterName given while adding k8s cluster  	| `""`                                                    |
+| `kubernetes.cluster_name`       | ClusterName given while adding k8s cluster  	| `""`                                                |
+| `kubernetes.multiline_concat_key`       | Key to look for fluentD to concatenate multiline logs   	| `"message"`                     |
+
 
 ### Avaialble Environment variables
 For descriptions see: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter
@@ -76,3 +78,19 @@ Anomaly detection will be done on `namespace` and `service`
 #### Multiline log support for k8s lm logs
 To use regexp to match beginning of multiline set `kubernetes.multiline_start_regexp=<some-regex-pattern>`
 by default the regex is set to `/^\[(\d{4}-)?\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}.*\]/`
+
+### Logs appearing in cri format
+If conatiner runtime is containerD or cri-o, on lm-logs ui you might see logs with prefix eg.
+```
+2016-10-06T00:17:09.669794202Z stdout F The content of the log entry 1
+```
+To solve this we need to install lm-logs with following command :
+```
+helm upgrade --install -n <namespace> \
+--set lm_company_name="<comapny>" \
+--set lm_access_id="<access_id>" \
+--set lm_access_key="<access_key"> \
+--set env.FLUENT_CONTAINER_TAIL_PARSER_TYPE="cri" \
+--set kubernetes.multiline_concat_key="log" \
+lm-logs logicmonitor/lm-logs
+```

--- a/charts/lm-logs/templates/configmap.yaml
+++ b/charts/lm-logs/templates/configmap.yaml
@@ -79,7 +79,7 @@ data:
 
     <filter kubernetes.**>
       @type concat
-      key log
+      key {{ .Values.kubernetes.multiline_concat_key }}
       seperator ""
       multiline_start_regexp {{ .Values.kubernetes.multiline_start_regexp }}
       timeout_label @NORMAL

--- a/charts/lm-logs/values.schema.json
+++ b/charts/lm-logs/values.schema.json
@@ -313,6 +313,9 @@
         },
         "cluster_name" : {
           "type": "string"
+        },
+        "multiline_concat_key" : {
+          "type": "string"
         }
       }
     },

--- a/charts/lm-logs/values.yaml
+++ b/charts/lm-logs/values.yaml
@@ -39,6 +39,7 @@ fluent:
 
 kubernetes:
   multiline_start_regexp: /^\[(\d{4}-)?\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}.*\]/
+  multiline_concat_key: message
 
 nodeSelector: {}
 affinity: {}


### PR DESCRIPTION
Add multiline_concat_key to determine which key to be 
used while concatenating multi line logs with Fluentd.
For container runtime container-d/cri-o we needed to 
do some direct modification with configmap as it was
not available with values file. 
We have added new field in values for multiline_concat_key. 