### PR TITLE
feat(lmotel): add support of proxy in lmotel

### DIFF
--- a/charts/lmotel/Chart.yaml
+++ b/charts/lmotel/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
 - name: LogicMonitor
   email: lmotel@logicmonitor.com
 name: lmotel
-version: 1.8.0-rc01
+version: 1.9.0-rc01
 home: https://logicmonitor.github.io/helm-charts-qa
 appVersion: v2.0.10
 dependencies:

--- a/charts/lmotel/README.md
+++ b/charts/lmotel/README.md
@@ -65,6 +65,11 @@ To enable logs add the following option
 --set logs.enable=true \
 ```
 
+To enable proxy support add the following option
+``` console
+--set envVars.HTTPS_PROXY=<proxy_server_ip:port> \
+```
+
 ---
 Required Values:
 - **account (default: `""`):** The LogicMonitor account name.

--- a/charts/lmotel/templates/daemonset.yaml
+++ b/charts/lmotel/templates/daemonset.yaml
@@ -73,6 +73,10 @@ spec:
                   optional: true
             - name: LOGICMONITOR_OTEL_NAMESPACE
               value: {{ include "lmutil.release.namespace" . }}
+          {{- range $key, $val := .Values.envVars }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+          {{- end }}
           {{- if .Values.external_config.lmconfig }}
           args: 
             - --config

--- a/charts/lmotel/templates/statefulset.yaml
+++ b/charts/lmotel/templates/statefulset.yaml
@@ -77,6 +77,10 @@ spec:
                   optional: true
             - name: LOGICMONITOR_OTEL_NAMESPACE
               value: {{ include "lmutil.release.namespace" . }}
+          {{- range $key, $val := .Values.envVars }}
+            - name: {{ $key }}
+              value: {{ $val | quote }}
+          {{- end }}
           {{- if .Values.external_config.lmconfig}}
           args: 
               - --config

--- a/charts/lmotel/values.schema.json
+++ b/charts/lmotel/values.schema.json
@@ -252,6 +252,11 @@
 			"examples": [
 			]
 		},
+		"envVars": {
+			"$id": "#properties/envVars", 
+			"title": "Environment Variables", 
+			"type": "object"
+		},
 		"ingress": {
 			"$id": "#properties/ingress", 
 			"title": "LMOTEL Collector Ingress schema", 

--- a/charts/lmotel/values.yaml
+++ b/charts/lmotel/values.yaml
@@ -39,6 +39,8 @@ external_config:
   lmconfig: ""
 arguments: []
 
+envVars: {}
+
 ingress:
   enabled: false
   annotations: {}


### PR DESCRIPTION
Expose HTTPS_PROXY proxy environment variable to enable proxy routing in lmotel collector.