### PR TITLE
ci(lm-container): update lm-container with lm-logs 0.6.0-rc01

### DIFF
--- a/charts/lm-container/Chart.yaml
+++ b/charts/lm-container/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lm-container
 description: A Helm chart for Logicmonitor's Kubernetes monitoring solutions
 type: application
-version: 7.1.0-rc01
+version: 7.1.0-rc02
 maintainers:
   - name: LogicMonitor
     email: argus@logicmonitor.com
@@ -33,7 +33,7 @@ dependencies:
       - monitoring
   - name: lm-logs
     # need to explicitly quote to make it string, else json schema fails
-    version: "0.5.1-rc01"
+    version: "0.6.0-rc01"
     repository: https://logicmonitor.github.io/helm-charts-qa
     # uncomment to test umbrella chart in while developing
     # repository: file://../lm-logs


### PR DESCRIPTION
update lm-container with lm-logs 0.6.0-rc01.
Appropriate User-Agent is now configurable and,
cluster_name is also populated