### PR TITLE
feat(argus): default disable resources

### DIFF
--- a/charts/argus/Chart.yaml
+++ b/charts/argus/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   - email: argus@logicmonitor.com
     name: LogicMonitor
 name: argus
-version: 11.1.0-rt01
+version: 11.1.1-rc01
 home: https://logicmonitor.github.io/helm-charts-qa
 appVersion: v15.1.0-rt01
 dependencies:

--- a/charts/argus/Chart.yaml
+++ b/charts/argus/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: argus
 version: 11.1.1-rc01
 home: https://logicmonitor.github.io/helm-charts-qa
-appVersion: v15.1.0-rt01
+appVersion: v15.2.0-rc01
 dependencies:
   - name: lmutil
     repository: https://logicmonitor.github.io/helm-charts-qa

--- a/charts/argus/Chart.yaml
+++ b/charts/argus/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: argus
 version: 11.1.1-rc01
 home: https://logicmonitor.github.io/helm-charts-qa
-appVersion: v15.2.0-rc01
+appVersion: v15.2.0-rc02
 dependencies:
   - name: lmutil
     repository: https://logicmonitor.github.io/helm-charts-qa

--- a/charts/argus/templates/_filter_config.tpl
+++ b/charts/argus/templates/_filter_config.tpl
@@ -1,7 +1,7 @@
 {{/* vim: set filetype=mustache: */}}
 
 {{- define "filter-config" -}}
-{{- $disabledBatchingFilter := "contains(owner,\"Job\") && type == \"pod\"" }}
+{{- $disabledBatchingFilter := "contains(owner,\"Job,CronJob\") && type == \"pod\"" }}
 {{- $filterValues := append .Values.filters ($disabledBatchingFilter) }}
 filters:
   {{ toYaml $filterValues | nindent 2 }}

--- a/charts/argus/templates/_filter_config.tpl
+++ b/charts/argus/templates/_filter_config.tpl
@@ -1,0 +1,8 @@
+{{/* vim: set filetype=mustache: */}}
+
+{{- define "filter-config" -}}
+{{- $disabledBatchingFilter := "contains(owner,\"Job\") && type == \"pod\"" }}
+{{- $filterValues := append .Values.filters ($disabledBatchingFilter) }}
+filters:
+  {{ toYaml $filterValues | nindent 2 }}
+{{- end -}}

--- a/charts/argus/templates/_helpers.tpl
+++ b/charts/argus/templates/_helpers.tpl
@@ -45,7 +45,7 @@ logicmonitor.com/provider: lm-container
 {{- define "monitoring.disable" }}
 {{ $alwaysDisable := list }}
 {{- if eq .Values.monitoringMode "Minimal" }}
-{{ $alwaysDisable = list "resourcequotas" "limitranges" "roles" "rolebindings" "networkpolicies" "configmaps" "clusterrolebindings" "clusterroles" "priorityclasses" "storageclasses" "cronjobs" "jobs" "endpoints" "ingresses" "secrets" "serviceaccounts" }}
+{{ $alwaysDisable = list "resourcequotas" "limitranges" "roles" "rolebindings" "networkpolicies" "configmaps" "clusterrolebindings" "clusterroles" "priorityclasses" "storageclasses" "cronjobs" "jobs" "endpoints" "ingresses" "secrets" "serviceaccounts" "poddisruptionbudgets" "customresourcedefinitions" }}
 {{- end }}
 
 {{ $resultList := ( concat $alwaysDisable $.Values.monitoring.disable | uniq )  }}

--- a/charts/argus/templates/_helpers.tpl
+++ b/charts/argus/templates/_helpers.tpl
@@ -44,6 +44,10 @@ logicmonitor.com/provider: lm-container
 
 {{- define "monitoring.disable" }}
 {{ $alwaysDisable := list }}
+{{- if eq .Values.monitoringMode "Minimal" }}
+{{ $alwaysDisable = list "resourcequotas" "limitranges" "roles" "rolebindings" "networkpolicies" "configmaps" "clusterrolebindings" "clusterroles" "priorityclasses" "storageclasses" "cronjobs" "jobs" "endpoints" "ingresses" "secrets" "serviceaccounts" }}
+{{- end }}
+
 {{ $resultList := ( concat $alwaysDisable $.Values.monitoring.disable | uniq )  }}
 {{- toYaml $resultList | nindent 0}}
 {{- end }}

--- a/charts/argus/templates/configmap.yaml
+++ b/charts/argus/templates/configmap.yaml
@@ -17,6 +17,5 @@ data:
     {{- include "argus-config" . | fromYaml | toYaml | nindent 4 }}
   filters-config.yaml: |
     {{- include "filter-config" . | fromYaml | toYaml | nindent 4 }}
-{{/*    filters: {{- toYaml .Values.filters | nindent 6 }}*/}}
   collectorConfig: |
     {{- include "collector-config" . | fromYaml | toYaml | nindent 4 }}

--- a/charts/argus/templates/configmap.yaml
+++ b/charts/argus/templates/configmap.yaml
@@ -16,6 +16,7 @@ data:
   config.yaml: |
     {{- include "argus-config" . | fromYaml | toYaml | nindent 4 }}
   filters-config.yaml: |
-    filters: {{- toYaml .Values.filters | nindent 6 }}
+    {{- include "filter-config" . | fromYaml | toYaml | nindent 4 }}
+{{/*    filters: {{- toYaml .Values.filters | nindent 6 }}*/}}
   collectorConfig: |
     {{- include "collector-config" . | fromYaml | toYaml | nindent 4 }}

--- a/charts/argus/values.schema.json
+++ b/charts/argus/values.schema.json
@@ -180,6 +180,34 @@
       ],
       "$comment": "ui:accessId-ignore tf:optional"
     },
+    "disableBatchingPods": {
+      "$id": "#/properties/disableBatchingPods",
+      "type": "boolean",
+      "title": "Disable Pods created by Jobs / CronJobs",
+      "description": "Disable Pods created by Jobs / CronJobs",
+      "default": "true",
+      "examples": [
+        "true",
+        "false"
+      ],
+      "$comment": "ui:accessKey-ignore tf:optional"
+    },
+    "monitoringMode": {
+      "$id": "#/properties/monitoringMode",
+      "type": "string",
+      "title": "Argus Monitoring Mode",
+      "description": "Monitoring mode for Argus (Minimal/Advanced)",
+      "default": "Minimal",
+      "enum": [
+        "Minimal",
+        "Advanced"
+      ],
+      "examples": [
+        "Minimal",
+        "Advanced"
+      ],
+      "$comment": "ui:accessKey-ignore tf:optional"
+    },
     "accessKey": {
       "$id": "#/properties/accessKey",
       "type": "string",

--- a/charts/argus/values.yaml
+++ b/charts/argus/values.yaml
@@ -65,6 +65,8 @@ log:
   level: "info"
 
 ksmUrl: ""
+monitoringMode: "Minimal"
+disableBatchingPods: true
 
 collectorsetcontroller:
   address: collectorset-controller
@@ -95,7 +97,22 @@ daemons:
     sysIpsWaitTimeout: '5m'
 monitoring:
   # list of resources to disable monitoring
-  disable: []
+  disable:
+  - resourcequotas
+  - limitranges
+  - roles
+  - rolebindings
+  - networkpolicies
+  - configmaps
+  - clusterrolebindings
+  - clusterroles
+  - priorityclasses
+  - storageclasses
+  - cronjobs
+  - jobs
+  - endpoints
+  - secrets
+  - serviceaccounts
   # annotations to be ignored while performing an update operation
   annotations:
     ignore: []

--- a/charts/argus/values.yaml
+++ b/charts/argus/values.yaml
@@ -113,6 +113,8 @@ monitoring:
   - endpoints
   - secrets
   - serviceaccounts
+  - poddisruptionbudgets
+  - customresourcedefinitions
   # annotations to be ignored while performing an update operation
   annotations:
     ignore: []

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,1 +1,11 @@
-module.exports = { extends: ['@commitlint/config-conventional'] };
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        'body-max-line-length' : [
+            2,
+            'always',
+            1000
+        ]
+    }
+};
+


### PR DESCRIPTION

- Resources for disabled monitoring will be the same as mentioned in [Default filtering](https://confluence.logicmonitor.com/display/ENG/Default+filtering+of+K8s+resources).
- ### Default disabled resources
- **Monitoring modes:**
	- Introduce options to set `Minimal`, `Advanced` monitoring options in helm chart.
	- `Minimal` monitoring will have limited number of resources enabled in monitoring.
	- `Advanced` monitoring will enable all resources to be monitored
- **Disable Pods created by Jobs:**
	- Pods created by Jobs / Cronjobs will be disabled by default
	- This will be under a flag `disableBatchedPods`, user can enable these Pods if required by toggling the flag
- **Default lm-container chart configuration**
	- Default monitoring mode will be `Advanced` set in the `lm-container` helm chart. Hence during an upgrade of `lm-container` from older version, it will preserve the configuration set by user.
	- `disableBatchedPods` will be set to `true` by default in helm chart. This will ignore the pods created by Jobs / Cronjobs by default.
