### PR TITLE
feat(mode): essentials upgrade

### DIFF
--- a/charts/argus/Chart.yaml
+++ b/charts/argus/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
   - email: argus@logicmonitor.com
     name: LogicMonitor
 name: argus
-version: 13.1.0-rt01
+version: 13.2.0-rc01
 home: https://logicmonitor.github.io/helm-charts-qa
 appVersion: v17.1.0-rt01
 dependencies:

--- a/charts/argus/templates/_helpers.tpl
+++ b/charts/argus/templates/_helpers.tpl
@@ -44,7 +44,7 @@ logicmonitor.com/provider: lm-container
 
 {{- define "monitoring.disable" }}
 {{ $alwaysDisable := list }}
-{{- if or (has .Values.monitoringMode (list "Minimal" "Essentials" "Essential")) (and (has .Values.monitoringMode (list "")) (not (.Release.IsUpgrade))) }}
+{{- if or (has .Values.monitoringMode (list "Minimal" "Essentials" "Essential")) (and (eq .Values.monitoringMode "") (not (.Release.IsUpgrade))) }}
 {{ $alwaysDisable = list "resourcequotas" "limitranges" "roles" "rolebindings" "networkpolicies" "configmaps" "clusterrolebindings" "clusterroles" "priorityclasses" "storageclasses" "cronjobs" "jobs" "endpoints" "ingresses" "secrets" "serviceaccounts" "poddisruptionbudgets" "customresourcedefinitions" }}
 {{- end }}
 

--- a/charts/argus/templates/_helpers.tpl
+++ b/charts/argus/templates/_helpers.tpl
@@ -44,7 +44,7 @@ logicmonitor.com/provider: lm-container
 
 {{- define "monitoring.disable" }}
 {{ $alwaysDisable := list }}
-{{- if and (not .Release.IsUpgrade) (has .Values.monitoringMode (list "Minimal" "Essentials" "Essential")) }}
+{{- if or (has .Values.monitoringMode (list "Minimal" "Essentials" "Essential")) (and (has .Values.monitoringMode (list "")) (not (.Release.IsUpgrade))) }}
 {{ $alwaysDisable = list "resourcequotas" "limitranges" "roles" "rolebindings" "networkpolicies" "configmaps" "clusterrolebindings" "clusterroles" "priorityclasses" "storageclasses" "cronjobs" "jobs" "endpoints" "ingresses" "secrets" "serviceaccounts" "poddisruptionbudgets" "customresourcedefinitions" }}
 {{- end }}
 

--- a/charts/argus/values.schema.json
+++ b/charts/argus/values.schema.json
@@ -197,8 +197,9 @@
       "type": "string",
       "title": "Argus Monitoring Mode",
       "description": "Monitoring mode for Argus (Essential/Advanced)",
-      "default": "Essential",
+      "default": "",
       "enum": [
+        "",
         "Minimal",
         "Essentials",
         "Essential",

--- a/charts/argus/values.yaml
+++ b/charts/argus/values.yaml
@@ -65,7 +65,7 @@ log:
   level: "info"
 
 ksmUrl: ""
-monitoringMode: "Minimal"
+monitoringMode: ""
 disableBatchingPods: true
 
 collectorsetcontroller:


### PR DESCRIPTION
- ## Description
	- User installs Argus with `Essentials` montoringMode.
	- While installing, no filters or monitoringDisabled configuration is set.
	- When customer performs an upgrade, with default monitoringMode which results to monitoringMode being set to `Advanced`.
	- This enables monitoring for all the resources in Kubernetes cluster.
	- Helm lacks capability to identify or recall setting from the previous installation.
	- This prevents `lm-container` from checking the previous monitoringMode configuration for carrying forward.
- ## Solution
	- Introduce an `empty` state in monitoringMode. This will be a default state if nothing is mentioned in `monitoringMode`.
	- Customer can specify a particular `monitoringMode` in case of some custom installation.