### PR TITLE
fix(logs): logs version upgrade in lm-container

### DIFF
--- a/charts/lm-container/Chart.yaml
+++ b/charts/lm-container/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: lm-container
 description: A Helm chart for Logicmonitor's Kubernetes monitoring solutions
 type: application
-version: 11.2.0-rc01
+version: 11.3.0-rc01
 maintainers:
   - name: LogicMonitor
     email: argus@logicmonitor.com
@@ -33,7 +33,7 @@ dependencies:
       - monitoring
   - name: lm-logs
     # need to explicitly quote to make it string, else json schema fails
-    version: "0.6.0-rc01"
+    version: "0.7.0-rc01"
     repository: https://logicmonitor.github.io/helm-charts-qa
     # uncomment to test umbrella chart in while developing
     # repository: file://../lm-logs


### PR DESCRIPTION
Upgrading the lm-logs version to 0.7.0-rc01 in lm-container helm chart.