### PR TITLE
feat(extras): added support for extra objects

### DIFF
--- a/charts/argus/templates/extraObject.yaml
+++ b/charts/argus/templates/extraObject.yaml
@@ -1,0 +1,6 @@
+{{- if .Values.extraObjects }}
+{{- range $index, $object := .Values.extraObjects }}
+---
+{{ toYaml $object | nindent 0 }}
+{{- end }}
+{{- end }}

--- a/charts/argus/values.schema.json
+++ b/charts/argus/values.schema.json
@@ -2353,6 +2353,12 @@
       },
       "additionalProperties": false
     },
+    "extraObjects": {
+      "$id": "#/properties/extraObjects",
+      "type": "array",
+      "additionalProperties": true,
+      "properties": {}
+    },
     "global": {
       "$id": "#/properties/global",
       "type": "object",


### PR DESCRIPTION
- Added support for extra objects in argus helm chart
## How to add extra objects
- Following is the yaml configuration for addi. Here as an extra object I have added a Kubernetes configmap
  ```yaml
  argus:
   extraObjects:
    - apiVersion: v1
      kind: ConfigMap
      metadata:
        name: extra-config
      data:
        key1: value1
        key2: value2
  ```
- This adds the listed configmap when argus is installed