### PR TITLE
feat(argus): fix replicas=0 being overridden to 1 in Argus deployment

### DIFF
--- a/charts/argus/Chart.yaml
+++ b/charts/argus/Chart.yaml
@@ -6,9 +6,9 @@ maintainers:
   - email: argus@logicmonitor.com
     name: LogicMonitor
 name: argus
-version: 15.2.0-rt01
+version: 15.2.1-rc01
 home: https://logicmonitor.github.io/helm-charts-qa
-appVersion: v18.2.0-rt01
+appVersion: v18.2.1-rc01
 dependencies:
   - name: lmutil
     repository: https://logicmonitor.github.io/helm-charts-qa

--- a/charts/argus/templates/deployment.yaml
+++ b/charts/argus/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
     checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
     checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
 spec:
-  replicas: {{ .Values.replicas | default 1 }}
+  replicas: {{- if hasKey .Values "replicas" }} {{ .Values.replicas }}{{- else }} 1{{- end }}
   selector:
     matchLabels:
       {{ include "lmutil.selectorLabels" . | nindent 6 }}

--- a/charts/collectorset-controller/Chart.yaml
+++ b/charts/collectorset-controller/Chart.yaml
@@ -6,9 +6,9 @@ maintainers:
   - email: argus@logicmonitor.com
     name: LogicMonitor
 name: collectorset-controller
-version: 12.6.0-rt01
+version: 12.6.1-rc01
 home: https://logicmonitor.github.io/helm-charts-qa
-appVersion: v13.6.0-rt01
+appVersion: v13.6.1-rc01
 dependencies:
   - name: lmutil
     repository: https://logicmonitor.github.io/helm-charts-qa


### PR DESCRIPTION
Fix handling of replicas=0 in Argus deployment

Ensure that explicitly setting replicas to 0 is respected instead of defaulting to 1.