### PR TITLE
feat(lm-logs): add configurable monitor_agent

### DIFF
--- a/charts/lm-logs/Chart.yaml
+++ b/charts/lm-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for sending k8s logs to Logic Monitor
 name: lm-logs
-version: 1.1.0-rc02
+version: 1.1.0-rc04
 maintainers:
   - email: dev@logicmonitor.com
     name: LogicMonitor

--- a/charts/lm-logs/Chart.yaml
+++ b/charts/lm-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for sending k8s logs to Logic Monitor
 name: lm-logs
-version: 1.1.0-rc04
+version: 1.1.1-rc01
 maintainers:
   - email: dev@logicmonitor.com
     name: LogicMonitor

--- a/charts/lm-logs/README.md
+++ b/charts/lm-logs/README.md
@@ -63,7 +63,55 @@ The following tables lists the configurable parameters of the lm-logs chart and 
 | `kubernetes.multiline_start_regexp` | Regexp to match beginning of multiline	| `/^\[(\d{4}-)?\d{2}-\d{2} \d{2}:\d{2}:\d{2}.\d{3}.*\]/` |
 | `kubernetes.cluster_name`       | (Required) Cluster name given while adding k8s cluster. Must be set for both standalone lm-logs and lm-container with lm-logs.  	| `""`                                                |
 | `kubernetes.multiline_concat_key`       | Key to look for fluentD to concatenate multiline logs   	| `"log"`                     |
+| `fluent.monitorAgent.enabled`           | Enable Fluentd monitor_agent to expose buffer metrics via HTTP | `false`                     |
+| `fluent.monitorAgent.bind`              | Bind address for monitor_agent HTTP server     | `0.0.0.0`                   |
+| `fluent.monitorAgent.port`              | Listen port for monitor_agent HTTP server      | `24220`                     |
 
+
+### Monitor Agent (Buffer Metrics)
+
+The `fluent.monitorAgent` feature exposes Fluentd plugin and buffer metrics via HTTP, allowing clients to monitor buffer usage and plugin status in real-time.
+
+#### Enable Monitor Agent
+
+To enable the monitor agent:
+
+```bash
+helm install lm-logs logicmonitor/lm-logs -n <namespace> \
+  --set lm_company_name="<company>" \
+  --set lm_access_id="<access_id>" \
+  --set lm_access_key="<access_key>" \
+  --set kubernetes.cluster_name="<cluster_name>" \
+  --set fluent.monitorAgent.enabled=true
+```
+
+Or in your values file:
+
+```yaml
+fluent:
+  monitorAgent:
+    enabled: true
+    bind: 0.0.0.0
+    port: 24220
+```
+
+#### Access Monitor Metrics
+
+After enabling, you can access the metrics endpoint:
+
+```bash
+# Port forward to a pod
+kubectl port-forward ds/lm-logs 24220:24220 -n <namespace>
+
+# Query the metrics endpoint
+curl http://127.0.0.1:24220/api/plugins.json
+```
+
+This provides insights into:
+- Plugin status and configuration
+- Buffer queue size and memory usage
+- Retry counts and backoff state
+- Flush metrics and performance data
 
 ### Available Environment variables
 For descriptions see: https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter

--- a/charts/lm-logs/templates/configmap.yaml
+++ b/charts/lm-logs/templates/configmap.yaml
@@ -21,6 +21,14 @@ data:
       log_level "#{ENV['FLUENT_LOG_LEVEL'] || 'warn'}"
     </system>
 
+    {{- if .Values.fluent.monitorAgent.enabled }}
+    <source>
+      @type monitor_agent
+      bind {{ .Values.fluent.monitorAgent.bind | default "0.0.0.0" }}
+      port {{ .Values.fluent.monitorAgent.port | default 24220 }}
+    </source>
+    {{- end }}
+
     <label @PROCESS_AFTER_CONCAT>
       {{- if .Values.useSystemdConf }}
       <filter {{ .Values.systemd.tag | default "systemd.al2023" }}>

--- a/charts/lm-logs/templates/deamonset.yaml
+++ b/charts/lm-logs/templates/deamonset.yaml
@@ -51,6 +51,12 @@ spec:
                 secretKeyRef:
                   {{- include "lm-logs.secretKeyRef" (dict "ctx" . "key" "bearerToken") | nindent 18 }}
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+          {{- if .Values.fluent.monitorAgent.enabled }}
+          ports:
+            - name: monitor-agent
+              containerPort: {{ .Values.fluent.monitorAgent.port | default 24220 }}
+              protocol: TCP
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/charts/lm-logs/values.schema.json
+++ b/charts/lm-logs/values.schema.json
@@ -310,6 +310,28 @@
           "default": "",
           "description": "Raw Fluentd filter config injected after kubernetes_metadata enrichment inside <label @PROCESS_AFTER_CONCAT>. Use for grep include/exclude filters."
         },
+        "monitorAgent": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Fluentd monitor_agent configuration. When enabled, a <source> block exposing plugin/buffer metrics over HTTP is added to the ConfigMap and the corresponding port is exposed on the DaemonSet container.",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "default": false,
+              "description": "If true, configures the monitor_agent <source> in the Fluentd config and exposes the port on the container."
+            },
+            "bind": {
+              "type": "string",
+              "default": "0.0.0.0",
+              "description": "Bind address for the monitor_agent HTTP server."
+            },
+            "port": {
+              "type": "integer",
+              "default": 24220,
+              "description": "Listen port for the monitor_agent HTTP server."
+            }
+          }
+        },
         "buffer": {
           "type": "object",
           "additionalProperties": false,

--- a/charts/lm-logs/values.yaml
+++ b/charts/lm-logs/values.yaml
@@ -89,6 +89,18 @@ fluent:
     #   total_limit_size: 8gb
     #   compress: gzip   # text|gzip
 
+  # Fluentd monitor_agent exposes plugin/buffer metrics over HTTP.
+  # When enabled, a <source> block is added to the ConfigMap and the
+  # corresponding port is exposed on the DaemonSet container so that
+  # clients can scrape buffer metrics (e.g. via `kubectl port-forward`).
+  #
+  # Example query (after `kubectl port-forward` to the pod):
+  #   curl http://127.0.0.1:24220/api/plugins.json
+  monitorAgent:
+    enabled: false
+    bind: 0.0.0.0
+    port: 24220
+
 systemd:
   tag: ""
   conf: ""


### PR DESCRIPTION

- Add fluent.monitorAgent config block (enabled, bind, port) to expose Fluentd plugin/buffer metrics via HTTP when enabled
- Conditionally inject <source @type monitor_agent> into ConfigMap
- Conditionally expose containerPort on DaemonSet when monitor_agent.enabled=true
- Update values.schema.json with monitorAgent field definition
- Bump chart version to 1.1.0-rc04

Feature is disabled by default; clients enable by setting:
  lm-logs:
    fluent:
      monitorAgent:
        enabled: true
        bind: 0.0.0.0
        port: 24220