### PR TITLE
feat(lmotel): read credentials from global.userDefinedSecret

### DIFF
--- a/charts/lmotel/Chart.yaml
+++ b/charts/lmotel/Chart.yaml
@@ -6,7 +6,7 @@ maintainers:
 - name: LogicMonitor
   email: lmotel@logicmonitor.com
 name: lmotel
-version: 1.9.0-rc01
+version: 1.10.0-rc01
 home: https://logicmonitor.github.io/helm-charts-qa
 appVersion: v2.0.10
 dependencies:

--- a/charts/lmotel/README.md
+++ b/charts/lmotel/README.md
@@ -60,6 +60,22 @@ helm install -n <namespace> \
 lmotel logicmonitor/lmotel
 ```
 
+#### User Defined Secret for LM credentials
+You can create a kubernetes secret with your LM credentials and pass the secret name to the chart.
+The secret must contain the following keys:
+- account
+- accessID
+- accessKey
+- bearerToken (if accessKey/accessID is not present in the secret)
+  Also, the authMode needs to be set accordingly. If the secret contains accessID/accessKey, authMode should be set to lmv1, otherwise bearer (similarly it should be set for the configurable parameters).
+
+Example install:
+
+``` console
+  --set global.userDefinedSecret=<your-secret-name> \
+  --set authMode=bearer
+```
+
 To enable logs add the following option
 ``` console
 --set logs.enable=true \
@@ -86,6 +102,8 @@ or
 Optional Values:
 - **replicaCount (default: `1`):** Number of replicas of lmotel kubernetes pod.
 - **otel_version (default: `""`):** Lmotel collector version.
+- **global.userDefinedSecret (default: `""`):** User Defined Secret for LM credentials
+- **authMode (default: `lmv1`):** Mode to use for authenticating requests sent to LM. Can be lmv1/bearer 
 - **arguments :** command line arguments for lmotel, can be passed as {--log-level, DEBUG}, other options can be added using comma separated values.
 ---
 

--- a/charts/lmotel/README.md
+++ b/charts/lmotel/README.md
@@ -66,25 +66,33 @@ The secret must contain the following keys:
 - account
 - accessID
 - accessKey
-- bearerToken (if accessKey/accessID is not present in the secret)
-  Also, the authMode needs to be set accordingly. If the secret contains accessID/accessKey, authMode should be set to lmv1, otherwise bearer (similarly it should be set for the configurable parameters).
+- bearerToken (for bearer-only auth), and/or accessID + accessKey (for LMv1). At least one complete set is required; the collector prefers LMv1 when both LMv1 credentials and a bearer token are present.
 
 Example install:
 
 ``` console
+helm install -n <namespace> \
   --set global.userDefinedSecret=<your-secret-name> \
-  --set authMode=bearer
+  --set lm.otel_name=<lmotel_collector_name> \
+  lmotel logicmonitor/lmotel
 ```
+
+When lmotel is installed as a dependency of **lm-container**, set `global.userDefinedSecret` on the **parent** release (for example in `lm-container-configuration.yaml`). Helm merges that root `global` into lmotel and it overrides `lmotel.global.userDefinedSecret` for the same key, so one umbrella-level Secret name stays authoritative.
 
 To enable logs add the following option
 ``` console
 --set logs.enable=true \
 ```
 
-To enable proxy support add the following option
+To enable proxy support:
+
+- **Without `global.userDefinedSecret`:** set a plain value (same as before):
+
 ``` console
---set envVars.HTTPS_PROXY=<proxy_server_ip:port> \
+--set envVars.HTTPS_PROXY=<proxy_server_ip_or_url> \
 ```
+
+- **With `global.userDefinedSecret`:** add a Secret data key **`https_proxy`** (base64-encoded value). The chart sets container env **`HTTPS_PROXY`** from that key via `secretKeyRef` (`optional: true`). In that case **`envVars.HTTPS_PROXY` is ignored** if set, to avoid duplicate env names.
 
 ---
 Required Values:
@@ -102,8 +110,7 @@ or
 Optional Values:
 - **replicaCount (default: `1`):** Number of replicas of lmotel kubernetes pod.
 - **otel_version (default: `""`):** Lmotel collector version.
-- **global.userDefinedSecret (default: `""`):** User Defined Secret for LM credentials
-- **authMode (default: `lmv1`):** Mode to use for authenticating requests sent to LM. Can be lmv1/bearer 
+- **global.userDefinedSecret (default: `""`):** Existing Secret for LM credentials (keys account, and either accessID+accessKey and/or bearerToken). At least one complete LMv1 pair or bearer token must be present; the collector prefers LMv1 when both are available. Optional key **`https_proxy`** supplies `HTTPS_PROXY` in the pod when this Secret is used.
 - **arguments :** command line arguments for lmotel, can be passed as {--log-level, DEBUG}, other options can be added using comma separated values.
 ---
 

--- a/charts/lmotel/ci/base-sanity-values.yaml
+++ b/charts/lmotel/ci/base-sanity-values.yaml
@@ -1,3 +1,5 @@
+authMode: "lmv1"
+
 lm:
   # The LogicMonitor API key ID.
   access_id: "dummy"
@@ -7,3 +9,8 @@ lm:
   account: "dummy"
   # The LMOTEL Collector name.
   otel_name: "dummy"
+
+global:
+  account: "dummyaccount"
+  accessID: "dummyid"
+  accessKey: "dummykey"

--- a/charts/lmotel/ci/base-sanity-values.yaml
+++ b/charts/lmotel/ci/base-sanity-values.yaml
@@ -1,5 +1,3 @@
-authMode: "lmv1"
-
 lm:
   # The LogicMonitor API key ID.
   access_id: "dummy"

--- a/charts/lmotel/templates/_helpers.tpl
+++ b/charts/lmotel/templates/_helpers.tpl
@@ -60,3 +60,107 @@ Check Ingress stability
 {{- define "ingress.isStable" -}}
   {{- eq (include "ingress.apiVersion" .) "networking.k8s.io/v1" -}}
 {{- end -}}
+
+{{/*
+Did the user set global.userDefinedSecret?
+*/}}
+{{- define "lmotel.userSecretSet" -}}
+{{- if .Values.global.userDefinedSecret }}true{{ end -}}
+{{- end -}}
+
+{{/*
+Return the credentials Secret name:
+- If global.userDefinedSecret is provided, use that.
+- Otherwise fall back to chart-managed Secret <fullname>.
+*/}}
+{{- define "lmotel.credsSecretName" -}}
+{{- if .Values.global.userDefinedSecret -}}
+{{- .Values.global.userDefinedSecret -}}
+{{- else -}}
+{{- include "lmutil.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/* True if we have any creds in any source (used by template fail-guard) */}}
+{{- define "lmotel.credsProvided" -}}
+{{- $uds := default "" .Values.global.userDefinedSecret -}}
+{{- $ga := default "" .Values.global.accessID -}}
+{{- $gk := default "" .Values.global.accessKey -}}
+{{- $va := default "" .Values.lm.access_id -}}
+{{- $vk := default "" .Values.lm.access_key -}}
+{{- $vb := default "" .Values.lm.bearer_token -}}
+{{- if or (ne $uds "")
+          (and (ne $ga "") (ne $gk ""))
+          (and (ne $va "") (ne $vk ""))
+          (ne $vb "") -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Emit a secretKeyRef block given a key name.
+Usage:
+  {{ include "lmotel.secretKeyRef" (dict "ctx" . "key" "bearerToken") | nindent 10 }}
+*/}}
+{{- define "lmotel.secretKeyRef" -}}
+name: {{ include "lmotel.credsSecretName" .ctx }}
+key: {{ .key }}
+optional: true
+{{- end -}}
+
+{{/* Validate credentials + account at render time */}}
+{{- define "lmotel.assertInputs" -}}
+{{- $ns := .Release.Namespace -}}
+{{- $mode := default "" .Values.authMode -}}
+{{- $uds  := default "" .Values.global.userDefinedSecret -}}
+
+{{- /* Fetch Secret if configured */ -}}
+{{- $sec := dict -}}
+{{- if ne $uds "" -}}
+  {{- $sec = lookup "v1" "Secret" $ns $uds | default dict -}}
+  {{- if not $sec }}
+    {{- fail (printf "global.userDefinedSecret=%q not found in namespace %q" $uds $ns) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- /* Helper: what keys exist in Secret? */ -}}
+{{- $hasSecKey := (and (ne $uds "")
+                        $sec.data
+                        (kindIs "map" $sec.data)) -}}
+{{- $secHas := dict -}}
+{{- if $hasSecKey -}}
+  {{- $_ := set $secHas "account"     (hasKey $sec.data "account") -}}
+  {{- $_ := set $secHas "accessID"    (hasKey $sec.data "accessID") -}}
+  {{- $_ := set $secHas "accessKey"   (hasKey $sec.data "accessKey") -}}
+  {{- $_ := set $secHas "bearerToken" (hasKey $sec.data "bearerToken") -}}
+{{- end -}}
+
+{{- /* 1) Enforce account name presence (values OR global OR Secret) */ -}}
+{{- $hasAccount := or
+      (ne (default "" .Values.lm.account) "")
+      (ne (default "" .Values.global.account) "")
+      (and (ne $uds "") ($secHas.account | default false)) -}}
+{{- if not $hasAccount -}}
+  {{- fail "Account name missing: set lm.account or global.account, or provide Secret with key 'account' via global.userDefinedSecret." -}}
+{{- end -}}
+
+{{- /* 2) Enforce credentials per authMode */ -}}
+{{- if eq $mode "lmv1" -}}
+  {{- $haslmv1FromSecret := and (ne $uds "") ($secHas.accessID | default false) ($secHas.accessKey | default false) -}}
+  {{- $haslmv1FromGlobal := and (ne (default "" .Values.global.accessID) "")
+                                (ne (default "" .Values.global.accessKey) "") -}}
+  {{- $haslmv1FromValues := and (ne (default "" .Values.lm.access_id) "")
+                                (ne (default "" .Values.lm.access_key) "") -}}
+  {{- if not (or $haslmv1FromSecret $haslmv1FromGlobal $haslmv1FromValues) -}}
+    {{- fail "LM v1 auth selected (authMode=lmv1) but no lmv1 found. Provide either: Secret with 'accessID'+'accessKey', or global.accessID+global.accessKey, or lm.access_id+lm.access_key." -}}
+  {{- end -}}
+
+{{- else if eq $mode "bearer" -}}
+  {{- $hasBearerFromSecret := and (ne $uds "") ($secHas.bearerToken | default false) -}}
+  {{- $hasBearerFromValues := ne (default "" .Values.lm.bearer_token) "" -}}
+  {{- if not (or $hasBearerFromSecret $hasBearerFromValues) -}}
+    {{- fail "Bearer auth selected (authMode=bearer) but no token found. Provide either: Secret with 'bearerToken' or lm.bearer_token in values." -}}
+  {{- end -}}
+
+{{- else -}}
+  {{- fail "authMode must be 'lmv1' or 'bearer'." -}}
+{{- end -}}
+{{- end -}}

--- a/charts/lmotel/templates/_helpers.tpl
+++ b/charts/lmotel/templates/_helpers.tpl
@@ -106,10 +106,14 @@ key: {{ .key }}
 optional: true
 {{- end -}}
 
-{{/* Validate credentials + account at render time */}}
+{{/*
+Validate credentials + account at render time.
+Collector uses LMv1 first, then bearer; chart requires at least one complete set:
+- LMv1: accessID+accessKey in user Secret, or global.accessID+global.accessKey, or lm.access_id+lm.access_key
+- Bearer: bearerToken in user Secret, or lm.bearer_token
+*/}}
 {{- define "lmotel.assertInputs" -}}
 {{- $ns := .Release.Namespace -}}
-{{- $mode := default "" .Values.authMode -}}
 {{- $uds  := default "" .Values.global.userDefinedSecret -}}
 
 {{- /* Fetch Secret if configured */ -}}
@@ -142,25 +146,16 @@ optional: true
   {{- fail "Account name missing: set lm.account or global.account, or provide Secret with key 'account' via global.userDefinedSecret." -}}
 {{- end -}}
 
-{{- /* 2) Enforce credentials per authMode */ -}}
-{{- if eq $mode "lmv1" -}}
-  {{- $haslmv1FromSecret := and (ne $uds "") ($secHas.accessID | default false) ($secHas.accessKey | default false) -}}
-  {{- $haslmv1FromGlobal := and (ne (default "" .Values.global.accessID) "")
-                                (ne (default "" .Values.global.accessKey) "") -}}
-  {{- $haslmv1FromValues := and (ne (default "" .Values.lm.access_id) "")
-                                (ne (default "" .Values.lm.access_key) "") -}}
-  {{- if not (or $haslmv1FromSecret $haslmv1FromGlobal $haslmv1FromValues) -}}
-    {{- fail "LM v1 auth selected (authMode=lmv1) but no lmv1 found. Provide either: Secret with 'accessID'+'accessKey', or global.accessID+global.accessKey, or lm.access_id+lm.access_key." -}}
-  {{- end -}}
-
-{{- else if eq $mode "bearer" -}}
-  {{- $hasBearerFromSecret := and (ne $uds "") ($secHas.bearerToken | default false) -}}
-  {{- $hasBearerFromValues := ne (default "" .Values.lm.bearer_token) "" -}}
-  {{- if not (or $hasBearerFromSecret $hasBearerFromValues) -}}
-    {{- fail "Bearer auth selected (authMode=bearer) but no token found. Provide either: Secret with 'bearerToken' or lm.bearer_token in values." -}}
-  {{- end -}}
-
-{{- else -}}
-  {{- fail "authMode must be 'lmv1' or 'bearer'." -}}
+{{- /* 2) At least one complete credential set (LMv1 pair OR bearer) */ -}}
+{{- $hasLMv1FromSecret := and (ne $uds "") ($secHas.accessID | default false) ($secHas.accessKey | default false) -}}
+{{- $hasLMv1FromGlobal := and (ne (default "" .Values.global.accessID) "")
+                              (ne (default "" .Values.global.accessKey) "") -}}
+{{- $hasLMv1FromValues := and (ne (default "" .Values.lm.access_id) "")
+                              (ne (default "" .Values.lm.access_key) "") -}}
+{{- $hasBearerFromSecret := and (ne $uds "") ($secHas.bearerToken | default false) -}}
+{{- $hasBearerFromValues := ne (default "" .Values.lm.bearer_token) "" -}}
+{{- $hasCreds := or $hasLMv1FromSecret $hasLMv1FromGlobal $hasLMv1FromValues $hasBearerFromSecret $hasBearerFromValues -}}
+{{- if not $hasCreds -}}
+  {{- fail "No complete LM credentials: provide LMv1 (accessID+accessKey in Secret, or global.accessID+global.accessKey, or lm.access_id+lm.access_key) and/or bearer (bearerToken in Secret or lm.bearer_token). Collector prefers LMv1 when both are available." -}}
 {{- end -}}
 {{- end -}}

--- a/charts/lmotel/templates/configmap.yaml
+++ b/charts/lmotel/templates/configmap.yaml
@@ -1,3 +1,7 @@
+{{- if not (include "lmotel.credsProvided" .) -}}
+{{- fail "Provide credentials via global.userDefinedSecret or via global.* / lm.* values." -}}
+{{- end -}}
+{{- include "lmotel.assertInputs" . -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -10,7 +14,7 @@ metadata:
     helm-revision: "{{ .Release.Revision }}"
     {{- include "lmotel.annotations" . | nindent 4 }}
 data:
-  lm_account: {{ if .Values.lm.account }} {{ .Values.lm.account }} {{ else }} {{ required "A valid .Values.lm.account or .Values.global.account entry is required!" .Values.global.account }} {{ end }}
+  lm_account: {{- if .Values.lm.account }} {{ .Values.lm.account }} {{- else if .Values.global.account }} {{ .Values.global.account }} {{- else if .Values.global.userDefinedSecret }} "" {{- else }} {{ required "A valid .Values.lm.account or .Values.global.account entry is required!" .Values.global.account }} {{- end }}
   lm_otel_name: {{ required "A valid .Values.lm.otel_name entry is required!" .Values.lm.otel_name }}
   {{- if or (.Values.lm.access_id) (.Values.global.accessID)}}
   lm_access_id: {{ if .Values.lm.access_id }} {{ .Values.lm.access_id }} {{ else }} {{ .Values.global.accessID  }} {{ end }}

--- a/charts/lmotel/templates/daemonset.yaml
+++ b/charts/lmotel/templates/daemonset.yaml
@@ -92,9 +92,19 @@ spec:
                   optional: true
             - name: LOGICMONITOR_OTEL_NAMESPACE
               value: {{ include "lmutil.release.namespace" . }}
+            {{- if .Values.global.userDefinedSecret }}
+            - name: HTTPS_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.userDefinedSecret }}
+                  key: https_proxy
+                  optional: true
+            {{- end }}
           {{- range $key, $val := .Values.envVars }}
+          {{- if or (not $.Values.global.userDefinedSecret) (ne $key "HTTPS_PROXY") }}
             - name: {{ $key }}
               value: {{ $val | quote }}
+          {{- end }}
           {{- end }}
           {{- if .Values.external_config.lmconfig }}
           args: 

--- a/charts/lmotel/templates/daemonset.yaml
+++ b/charts/lmotel/templates/daemonset.yaml
@@ -37,6 +37,24 @@ spec:
             {{ end }}
           {{- end }}
           env:
+            {{- if .Values.global.userDefinedSecret }}
+            - name: LOGICMONITOR_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  {{- include "lmotel.secretKeyRef" (dict "ctx" . "key" "account") | nindent 18 }}
+            - name: LOGICMONITOR_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{- include "lmotel.secretKeyRef" (dict "ctx" . "key" "bearerToken") | nindent 18 }}
+            - name: LOGICMONITOR_ACCESS_ID
+              valueFrom:
+                secretKeyRef:
+                  {{- include "lmotel.secretKeyRef" (dict "ctx" . "key" "accessID") | nindent 18 }}
+            - name: LOGICMONITOR_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  {{- include "lmotel.secretKeyRef" (dict "ctx" . "key" "accessKey") | nindent 18 }}
+            {{- else }}
             - name: LOGICMONITOR_ACCOUNT
               valueFrom:
                 configMapKeyRef:
@@ -60,6 +78,7 @@ spec:
                   name: {{ include "lmutil.fullname" . }}
                   key: lm_access_key
                   optional: true                
+            {{- end }}
             - name: LOGICMONITOR_OTEL_NAME
               valueFrom:
                 configMapKeyRef:

--- a/charts/lmotel/templates/secrets.yaml
+++ b/charts/lmotel/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.userDefinedSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,3 +14,4 @@ data:
   {{- if or (.Values.lm.access_key) (.Values.global.accessID)}}
   lm_access_key: {{ if .Values.lm.access_key }} {{ .Values.lm.access_key | b64enc }} {{ else }} {{ required "A valid .Values.lm.access_key or .Values.global.accessKey entry is required!" .Values.global.accessKey | b64enc }} {{ end }}
   {{ end }}
+{{- end }}

--- a/charts/lmotel/templates/statefulset.yaml
+++ b/charts/lmotel/templates/statefulset.yaml
@@ -96,9 +96,19 @@ spec:
                   optional: true
             - name: LOGICMONITOR_OTEL_NAMESPACE
               value: {{ include "lmutil.release.namespace" . }}
+            {{- if .Values.global.userDefinedSecret }}
+            - name: HTTPS_PROXY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.global.userDefinedSecret }}
+                  key: https_proxy
+                  optional: true
+            {{- end }}
           {{- range $key, $val := .Values.envVars }}
+          {{- if or (not $.Values.global.userDefinedSecret) (ne $key "HTTPS_PROXY") }}
             - name: {{ $key }}
               value: {{ $val | quote }}
+          {{- end }}
           {{- end }}
           {{- if .Values.external_config.lmconfig}}
           args: 

--- a/charts/lmotel/templates/statefulset.yaml
+++ b/charts/lmotel/templates/statefulset.yaml
@@ -41,6 +41,24 @@ spec:
             {{ end }}
           {{- end }}
           env:
+            {{- if .Values.global.userDefinedSecret }}
+            - name: LOGICMONITOR_ACCOUNT
+              valueFrom:
+                secretKeyRef:
+                  {{- include "lmotel.secretKeyRef" (dict "ctx" . "key" "account") | nindent 18 }}
+            - name: LOGICMONITOR_BEARER_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  {{- include "lmotel.secretKeyRef" (dict "ctx" . "key" "bearerToken") | nindent 18 }}
+            - name: LOGICMONITOR_ACCESS_ID
+              valueFrom:
+                secretKeyRef:
+                  {{- include "lmotel.secretKeyRef" (dict "ctx" . "key" "accessID") | nindent 18 }}
+            - name: LOGICMONITOR_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  {{- include "lmotel.secretKeyRef" (dict "ctx" . "key" "accessKey") | nindent 18 }}
+            {{- else }}
             - name: LOGICMONITOR_ACCOUNT
               valueFrom:
                 configMapKeyRef:
@@ -64,6 +82,7 @@ spec:
                   name: {{ include "lmutil.fullname" . }}
                   key: lm_access_key
                   optional: true                
+            {{- end }}
             - name: LOGICMONITOR_OTEL_NAME
               valueFrom:
                 configMapKeyRef:

--- a/charts/lmotel/values.schema.json
+++ b/charts/lmotel/values.schema.json
@@ -3,8 +3,7 @@
 	"title": "LMOTEL Helm Chart Configuration Schema", 
 	"type": "object",
 	"required": [
-		"lm",
-		"authMode"
+		"lm"
 	],
 	"additionalProperties": false,
 	"allOf": [
@@ -92,14 +91,6 @@
 				1
 			],
 			"default": 1
-		},
-		"authMode": {
-			"$id": "#/properties/authMode",
-			"description": "Authentication mode for LogicMonitor: use bearer for lm.bearer_token / Secret key lm_bearer_token; use lmv1 for access ID + access key (lm.* or global.* / Secret keys lm_access_key with ConfigMap access ID).",
-			"oneOf": [
-				{ "enum": ["bearer", "lmv1"] },
-				{ "type": "string", "maxLength": 0 }
-			]
 		},
 		"lm": {
 			"$id": "#properties/lm", 
@@ -719,7 +710,7 @@
 				"$id": "#/properties/global/properties/userDefinedSecret",
 				"type": "string",
 				"title": "Existing Kubernetes Secret name",
-				"description": "Name of a Secret in the release namespace with LM credentials (base64-encoded keys): account, and either bearerToken or accessID+accessKey. Align authMode with bearer vs lmv1. When set, the chart does not create a chart-managed credentials Secret and pods read these keys like lm-logs.",
+				"description": "Name of a Secret in the release namespace with LM credentials (base64-encoded keys): account, and either bearerToken or accessID+accessKey (at least one complete LMv1 pair or bearer token). Optional key https_proxy is exposed as container env HTTPS_PROXY via secretKeyRef when set; otherwise use envVars.HTTPS_PROXY.",
 				"default": "",
 				"examples": [
 				  "lmotel-credentials"

--- a/charts/lmotel/values.schema.json
+++ b/charts/lmotel/values.schema.json
@@ -3,9 +3,80 @@
 	"title": "LMOTEL Helm Chart Configuration Schema", 
 	"type": "object",
 	"required": [
-		"lm"
+		"lm",
+		"authMode"
 	],
 	"additionalProperties": false,
+	"allOf": [
+		{
+			"anyOf": [
+				{
+					"properties": {
+						"lm": {
+							"type": "object",
+							"required": ["bearer_token"]
+						}
+					}
+				},
+				{
+					"properties": {
+						"lm": {
+							"type": "object",
+							"required": ["access_id", "access_key"]
+						}
+					}
+				},
+				{
+					"required": ["global"],
+					"properties": {
+						"global": {
+							"type": "object",
+							"required": ["userDefinedSecret"]
+						}
+					}
+				},
+				{
+					"required": ["global"],
+					"properties": {
+						"global": {
+							"type": "object",
+							"required": ["accessID", "accessKey"]
+						}
+					}
+				}
+			]
+		},
+		{
+			"anyOf": [
+				{
+					"properties": {
+						"lm": {
+							"type": "object",
+							"required": ["account"]
+						}
+					}
+				},
+				{
+					"required": ["global"],
+					"properties": {
+						"global": {
+							"type": "object",
+							"required": ["account"]
+						}
+					}
+				},
+				{
+					"required": ["global"],
+					"properties": {
+						"global": {
+							"type": "object",
+							"required": ["userDefinedSecret"]
+						}
+					}
+				}
+			]
+		}
+	],
 	"properties": {
 		"enabled": {
 			"$id": "#/properties/enabled",
@@ -22,15 +93,19 @@
 			],
 			"default": 1
 		},
+		"authMode": {
+			"$id": "#/properties/authMode",
+			"description": "Authentication mode for LogicMonitor: use bearer for lm.bearer_token / Secret key lm_bearer_token; use lmv1 for access ID + access key (lm.* or global.* / Secret keys lm_access_key with ConfigMap access ID).",
+			"oneOf": [
+				{ "enum": ["bearer", "lmv1"] },
+				{ "type": "string", "maxLength": 0 }
+			]
+		},
 		"lm": {
 			"$id": "#properties/lm", 
 			"title": "lm", 
 			"type": "object",
 			"required": [
-				"account",
-				"bearer_token",
-				"access_id",
-				"access_key",
 				"otel_name"
 			],
 			"properties": {
@@ -639,6 +714,16 @@
 				  "lmqauat"
 				],
 				"$comment": "ui:account-ignore"
+			  },
+			  "userDefinedSecret": {
+				"$id": "#/properties/global/properties/userDefinedSecret",
+				"type": "string",
+				"title": "Existing Kubernetes Secret name",
+				"description": "Name of a Secret in the release namespace with LM credentials (base64-encoded keys): account, and either bearerToken or accessID+accessKey. Align authMode with bearer vs lmv1. When set, the chart does not create a chart-managed credentials Secret and pods read these keys like lm-logs.",
+				"default": "",
+				"examples": [
+				  "lmotel-credentials"
+				]
 			  }
 			}
 		}

--- a/charts/lmotel/values.yaml
+++ b/charts/lmotel/values.yaml
@@ -4,9 +4,6 @@
 
 replicaCount: 1
 
-# Authentication mode: lmv1 (access ID + key) or bearer (bearer token). Align with credentials you supply in values or global.userDefinedSecret.
-authMode: "lmv1"
-
 lm:
   account: ""
   bearer_token: ""

--- a/charts/lmotel/values.yaml
+++ b/charts/lmotel/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+# Authentication mode: lmv1 (access ID + key) or bearer (bearer token). Align with credentials you supply in values or global.userDefinedSecret.
+authMode: "lmv1"
+
 lm:
   account: ""
   bearer_token: ""
@@ -13,6 +16,12 @@ lm:
   otel_version: 0
 
 global:
+  userDefinedSecret: ""  # Uncomment and set to use a custom secret for credentials
+  # The referenced secret must contain the following keys (all base64 encoded):
+  #   account
+  #   accessID
+  #   accessKey
+  #   bearerToken
   accessID: ""
   accessKey: ""
   account: ""


### PR DESCRIPTION
Currently it is not possible to deploy the lm-container chart without providing values for lm_access_id and lm_access_key or lm_bearer_token as the lmotel subcharts require them to be set.

Other subcharts have been updated to read credentials from a secret via [global.userDefinedSecret]

Add support of reading credentials from global.userDefinedSecret in lmotel chart

This change lets the lmotel Helm chart use an existing Kubernetes Secret for LogicMonitor credentials, adds render-time validation of that secret and credential combinations, supports optional HTTPS_PROXY from the same secret.