### PR TITLE
feat(lm-logs): parameterised HTTP/S proxy support

### DIFF
--- a/charts/lm-logs/Chart.yaml
+++ b/charts/lm-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for sending k8s logs to Logic Monitor
 name: lm-logs
-version: 1.1.1-rc03
+version: 1.1.1-rc02
 maintainers:
   - email: dev@logicmonitor.com
     name: LogicMonitor

--- a/charts/lm-logs/Chart.yaml
+++ b/charts/lm-logs/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Helm chart for sending k8s logs to Logic Monitor
 name: lm-logs
-version: 1.1.1-rc01
+version: 1.1.1-rc03
 maintainers:
   - email: dev@logicmonitor.com
     name: LogicMonitor

--- a/charts/lm-logs/templates/_helpers.tpl
+++ b/charts/lm-logs/templates/_helpers.tpl
@@ -236,6 +236,53 @@ Return the appropriate apiVersion for rbac.
 {{- toYaml $envList | nindent 0 -}}
 {{- end -}}
 
+{{/*
+Render HTTP/S proxy env vars for the fluentd container.
+
+Precedence per field: .Values.proxy.<field>  >  .Values.global.proxy.<field>.
+If url is empty after fallback, nothing is rendered.
+If user/pass are set, they are URL-encoded and embedded into the URL as
+  scheme://user:pass@host:port
+Emits http_proxy, https_proxy and uppercase variants. no_proxy is emitted
+when noProxy is set (defaulted in values.yaml to cover the in-cluster API).
+*/}}
+{{- define "lm-logs.proxyEnv" -}}
+{{- $local  := default (dict) .Values.proxy -}}
+{{- $global := default (dict) (default (dict) .Values.global).proxy -}}
+{{- $url     := default (default "" $global.url)     $local.url -}}
+{{- $user    := default (default "" $global.user)    $local.user -}}
+{{- $pass    := default (default "" $global.pass)    $local.pass -}}
+{{- $noProxy := default (default "" $global.noProxy) $local.noProxy -}}
+{{- /* Safe default for no_proxy keeps the in-cluster API direct so the */ -}}
+{{- /* kubernetes_metadata filter doesn't tunnel kube API calls through the proxy. */ -}}
+{{- if and $url (not $noProxy) -}}
+  {{- $noProxy = "kubernetes.default.svc,.svc,.cluster.local,localhost,127.0.0.1" -}}
+{{- end -}}
+{{- if $url -}}
+{{- $finalUrl := $url -}}
+{{- if and $user $pass -}}
+  {{- $parts := regexSplit "://" $url 2 -}}
+  {{- if eq (len $parts) 2 -}}
+    {{- $finalUrl = printf "%s://%s:%s@%s" (index $parts 0) (urlquery $user) (urlquery $pass) (index $parts 1) -}}
+  {{- end -}}
+{{- end }}
+- name: http_proxy
+  value: {{ $finalUrl | quote }}
+- name: https_proxy
+  value: {{ $finalUrl | quote }}
+- name: HTTP_PROXY
+  value: {{ $finalUrl | quote }}
+- name: HTTPS_PROXY
+  value: {{ $finalUrl | quote }}
+{{- if $noProxy }}
+- name: no_proxy
+  value: {{ $noProxy | quote }}
+- name: NO_PROXY
+  value: {{ $noProxy | quote }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "fluentd-image" -}}
 "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
 {{- end -}}

--- a/charts/lm-logs/templates/deamonset.yaml
+++ b/charts/lm-logs/templates/deamonset.yaml
@@ -31,6 +31,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- include "lm-logs.proxyEnv" . | nindent 12 }}
             {{- if gt (len .Values.env) 0 }}
             {{- include "ds-env" . | nindent 12 }}
             {{- end }}

--- a/charts/lm-logs/values.schema.json
+++ b/charts/lm-logs/values.schema.json
@@ -174,6 +174,38 @@
           "examples": [
             "lm-logs-credentials"
           ]
+        },
+        "proxy": {
+          "type": "object",
+          "title": "Global HTTP/S proxy (fallback)",
+          "description": "Fallback proxy used when .Values.proxy.<field> is empty. Mirrors argus/lm-container global.proxy.",
+          "additionalProperties": false,
+          "default": {},
+          "properties": {
+            "url": {
+              "type": "string",
+              "default": "",
+              "description": "Proxy URL, e.g. http://proxy.corp:8080. Empty disables proxy.",
+              "$comment": "ui:proxyURL-ignore tf:optional"
+            },
+            "user": {
+              "type": "string",
+              "default": "",
+              "description": "Optional proxy auth user (URL-encoded into the URL when set).",
+              "$comment": "ui:proxyUser-ignore tf:optional"
+            },
+            "pass": {
+              "type": "string",
+              "default": "",
+              "description": "Optional proxy auth password (URL-encoded into the URL when set).",
+              "$comment": "ui:proxyPass-ignore tf:optional"
+            },
+            "noProxy": {
+              "type": "string",
+              "default": "",
+              "description": "Comma-separated no_proxy list."
+            }
+          }
         }
       }
     },
@@ -247,6 +279,42 @@
       ],
       "additionalProperties": {
         "type": "string"
+      }
+    },
+    "proxy": {
+      "$id": "#/properties/proxy",
+      "type": "object",
+      "title": "HTTP/S proxy for fluentd egress",
+      "description": "When proxy.url is set, the chart injects http_proxy/https_proxy/no_proxy (and uppercase variants) on the lm-logs DaemonSet. Falls back to global.proxy.<field> when unset. Credentials, if provided, are URL-encoded into the proxy URL.",
+      "additionalProperties": false,
+      "default": {},
+      "examples": [
+        { "url": "http://proxy.corp:8080", "user": "", "pass": "", "noProxy": "kubernetes.default.svc,.svc,.cluster.local,localhost,127.0.0.1" }
+      ],
+      "properties": {
+        "url": {
+          "type": "string",
+          "default": "",
+          "description": "Proxy URL, e.g. http://proxy.corp:8080. Empty disables proxy.",
+          "$comment": "ui:proxyURL-ignore tf:optional"
+        },
+        "user": {
+          "type": "string",
+          "default": "",
+          "description": "Optional proxy auth user (URL-encoded into the URL when set).",
+          "$comment": "ui:proxyUser-ignore tf:optional"
+        },
+        "pass": {
+          "type": "string",
+          "default": "",
+          "description": "Optional proxy auth password (URL-encoded into the URL when set).",
+          "$comment": "ui:proxyPass-ignore tf:optional"
+        },
+        "noProxy": {
+          "type": "string",
+          "default": "",
+          "description": "Comma-separated no_proxy list. Empty means the chart applies a safe default (in-cluster API + loopback). Setting this replaces the default - keep the kube API in scope or the kubernetes_metadata filter will break."
+        }
       }
     },
     "resources": {

--- a/charts/lm-logs/values.yaml
+++ b/charts/lm-logs/values.yaml
@@ -23,6 +23,14 @@ global:
   account: ""
   clusterName: ""
   companyDomain: ""
+  # HTTP/S proxy fallback when chart-local .Values.proxy.* is unset.
+  # Mirrors the argus/lm-container global.proxy convention so umbrella installs
+  # can configure a single proxy block once.
+  proxy:
+    url: ""
+    user: ""
+    pass: ""
+    noProxy: ""
 
 imagePullSecrets: []
 nameOverride: ""
@@ -32,6 +40,30 @@ labels: {}
 annotations: {}
 
 env: {}
+
+# HTTP/S proxy for the fluentd container's outbound traffic to LogicMonitor.
+# When proxy.url is set, the chart injects http_proxy, https_proxy, no_proxy
+# (and their uppercase variants) onto the DaemonSet container.
+#
+# If proxy.user / proxy.pass are set, they're URL-encoded and embedded into the
+# proxy URL (e.g. http://user:pass@host:port). If you do not want credentials
+# rendered into the manifest in plain text, leave proxy.user / proxy.pass empty
+# here and inject http_proxy via .Values.env from a Kubernetes Secret instead.
+#
+# noProxy defaults below cover the in-cluster API + loopback so the fluentd
+# kubernetes_metadata filter is not tunnelled through the proxy. Extend it with
+# your cluster's Service/Pod CIDRs if the defaults don't match.
+#
+# Precedence: .Values.proxy.<field>  >  .Values.global.proxy.<field>.
+proxy:
+  url: ""
+  user: ""
+  pass: ""
+  # Leave noProxy empty to use the chart's safe default
+  # ("kubernetes.default.svc,.svc,.cluster.local,localhost,127.0.0.1"), which
+  # keeps the kubernetes_metadata filter direct. Setting noProxy here replaces
+  # that default entirely; remember to include the in-cluster API CIDR.
+  noProxy: ""
 
 resources:
   limits:


### PR DESCRIPTION
Add proxy.{url,user,pass,noProxy} on lm-logs (with a matching global.proxy fallback) so customers can enable an outbound HTTP/S proxy via --set / values, without editing the DaemonSet template. Mirrors argus/lm-container conventions for consistent UX in standalone and umbrella installs.

- New helper lm-logs.proxyEnv emits http_proxy / https_proxy / no_proxy (plus uppercase variants) on the fluentd container only when a URL is configured. user/pass are URL-encoded into the URL.
- Safe default no_proxy (kubernetes.default.svc,.svc,.cluster.local, localhost,127.0.0.1) keeps the fluentd kubernetes_metadata filter direct so kube API calls are not tunnelled through the proxy.
- Precedence: .Values.proxy.<f> overrides .Values.global.proxy.<f>.
- values.schema.json updated for both blocks.
- Chart version bumped to 1.1.1-rc03.